### PR TITLE
Update README.md (Add website / fix User Manual to use https://www.ngscopeclient.org)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # scopehal-apps
 
+https://www.ngscopeclient.org
+
 Applications for libscopehal
 
 [C++ coding policy](https://github.com/azonenberg/coding-policy/blob/master/cpp-coding-policy.md)
 
 ## Installation
 
-Refer to the "getting started" chapter of [the manual](https://www.antikernel.net/temp/ngscopeclient-manual.pdf).
+Refer to the "getting started" chapter of the User manual
+* [User manual GettingStarted (HTML)](https://www.ngscopeclient.org/manual/GettingStarted.html)
+* [User manual (PDF)](https://www.ngscopeclient.org/downloads/ngscopeclient-manual.pdf)
 
 ## Special comments
 


### PR DESCRIPTION
Added main website https://www.ngscopeclient.org
Fixed link to latest user manuals / Getting Started (on https://www.ngscopeclient.org)