### PR TITLE
ngscopeclient: handle m_metricsDialog and m_historyDialog on dialog close

### DIFF
--- a/src/ngscopeclient/MainWindow.cpp
+++ b/src/ngscopeclient/MainWindow.cpp
@@ -975,10 +975,14 @@ void MainWindow::OnDialogClosed(const std::shared_ptr<Dialog>& dlg)
 	//Handle single-instance dialogs
 	if(m_logViewerDialog == dlg)
 		m_logViewerDialog = nullptr;
+	if(m_metricsDialog == dlg)
+		m_metricsDialog = nullptr;
 	if(m_timebaseDialog == dlg)
 		m_timebaseDialog = nullptr;
 	if(m_triggerDialog == dlg)
 		m_triggerDialog = nullptr;
+	if(m_historyDialog == dlg)
+		m_historyDialog = nullptr;
 	if(m_preferenceDialog == dlg)
 		m_preferenceDialog = nullptr;
 	if(m_persistenceDialog == dlg)


### PR DESCRIPTION
This fixes History and Performance Metrics menu items being greyed out after closing its respective dialog menu.