### PR TITLE
Move test initialization and teardown into Catch2 event listeners

### DIFF
--- a/tests/Acceleration/main.cpp
+++ b/tests/Acceleration/main.cpp
@@ -45,24 +45,34 @@ using namespace std;
 
 mt19937 g_rng;
 
+class testRunListener : public Catch::EventListenerBase {
+public:
+    using Catch::EventListenerBase::EventListenerBase;
+
+	// Global initialization
+    void testRunStarting(Catch::TestRunInfo const&) override {
+		g_log_sinks.emplace(g_log_sinks.begin(), new ColoredSTDLogSink(Severity::VERBOSE));
+
+		if(!VulkanInit())
+			exit(1);
+		TransportStaticInit();
+		DriverStaticInit();
+		InitializePlugins();
+
+		//Initialize the RNG
+		g_rng.seed(0);
+	}
+
+	//Clean up after the scope goes out of scope (pun not intended)
+    void testRunEnded(Catch::TestRunStats const& testRunStats) override {
+		ScopehalStaticCleanup();
+	}
+};
+CATCH_REGISTER_LISTENER(testRunListener)
+
+
 int main(int argc, char* argv[])
 {
-	g_log_sinks.emplace(g_log_sinks.begin(), new ColoredSTDLogSink(Severity::VERBOSE));
-
-	//Global scopehal initialization
-	if(!VulkanInit())
-		return 1;
-	TransportStaticInit();
-	DriverStaticInit();
-	InitializePlugins();
-
-	//Initialize the RNG
-	g_rng.seed(0);
-
 	//Run the actual test
-	int ret = Catch::Session().run(argc, argv);
-
-	//Clean up and return test results
-	ScopehalStaticCleanup();
-	return ret;
+	return Catch::Session().run(argc, argv);
 }

--- a/tests/Acceleration/main.cpp
+++ b/tests/Acceleration/main.cpp
@@ -38,6 +38,7 @@
 #include <catch2/catch_all.hpp>
 #else
 #include <catch2/catch.hpp>
+#define EventListenerBase TestEventListenerBase
 #endif
 #include "Acceleration.h"
 

--- a/tests/Acceleration/main.cpp
+++ b/tests/Acceleration/main.cpp
@@ -46,12 +46,14 @@ using namespace std;
 
 mt19937 g_rng;
 
-class testRunListener : public Catch::EventListenerBase {
+class testRunListener : public Catch::EventListenerBase
+{
 public:
     using Catch::EventListenerBase::EventListenerBase;
 
 	// Global initialization
-    void testRunStarting(Catch::TestRunInfo const&) override {
+    void testRunStarting(Catch::TestRunInfo const&) override
+    {
 		g_log_sinks.emplace(g_log_sinks.begin(), new ColoredSTDLogSink(Severity::VERBOSE));
 
 		if(!VulkanInit())
@@ -65,7 +67,8 @@ public:
 	}
 
 	//Clean up after the scope goes out of scope (pun not intended)
-    void testRunEnded(Catch::TestRunStats const& testRunStats) override {
+    void testRunEnded(Catch::TestRunStats const& testRunStats) override
+    {
 		ScopehalStaticCleanup();
 	}
 };

--- a/tests/Filters/Filter_Add.cpp
+++ b/tests/Filters/Filter_Add.cpp
@@ -51,7 +51,7 @@ void AddCpu(UniformAnalogWaveform* pout, UniformAnalogWaveform* pa, UniformAnalo
 TEST_CASE("Filter_Add")
 {
 	auto filter = dynamic_cast<AddFilter*>(Filter::CreateFilter("Add", "#ffffff"));
-	REQUIRE(filter != NULL);
+	REQUIRE(filter != nullptr);
 	filter->AddRef();
 
 	//Create a queue and command buffer

--- a/tests/Filters/Filter_FFT.cpp
+++ b/tests/Filters/Filter_FFT.cpp
@@ -61,7 +61,7 @@ void BlackmanHarrisWindow(const float* data, size_t len, float* out);
 TEST_CASE("Filter_FFT")
 {
 	auto filter = dynamic_cast<FFTFilter*>(Filter::CreateFilter("FFT", "#ffffff"));
-	REQUIRE(filter != NULL);
+	REQUIRE(filter != nullptr);
 	filter->AddRef();
 
 	//Create a queue and command buffer

--- a/tests/Filters/Filter_Subtract.cpp
+++ b/tests/Filters/Filter_Subtract.cpp
@@ -51,7 +51,7 @@ void SubtractCpu(UniformAnalogWaveform* pout, UniformAnalogWaveform* pa, Uniform
 TEST_CASE("Filter_Subtract")
 {
 	auto filter = dynamic_cast<SubtractFilter*>(Filter::CreateFilter("Subtract", "#ffffff"));
-	REQUIRE(filter != NULL);
+	REQUIRE(filter != nullptr);
 	filter->AddRef();
 
 	//Create a queue and command buffer

--- a/tests/Filters/Filter_Upsample.cpp
+++ b/tests/Filters/Filter_Upsample.cpp
@@ -48,7 +48,7 @@ using namespace std;
 TEST_CASE("Filter_Upsample")
 {
 	auto filter = dynamic_cast<UpsampleFilter*>(Filter::CreateFilter("Upsample", "#ffffff"));
-	REQUIRE(filter != NULL);
+	REQUIRE(filter != nullptr);
 	filter->AddRef();
 
 	//Create a queue and command buffer

--- a/tests/Filters/FrequencyMeasurement.cpp
+++ b/tests/Filters/FrequencyMeasurement.cpp
@@ -49,7 +49,7 @@ TEST_CASE("Filter_FrequencyMeasurement")
 {
 	TestWaveformSource source(g_rng);
 	auto filter = dynamic_cast<FrequencyMeasurement*>(Filter::CreateFilter("Frequency", "#ffffff"));
-	REQUIRE(filter != NULL);
+	REQUIRE(filter != nullptr);
 	filter->AddRef();
 
 	const size_t niter = 25;
@@ -85,7 +85,7 @@ TEST_CASE("Filter_FrequencyMeasurement")
 
 			//Get the output data
 			auto data = dynamic_cast<SparseAnalogWaveform*>(filter->GetData(0));
-			REQUIRE(data != NULL);
+			REQUIRE(data != nullptr);
 
 			//Counts for each array must be consistent
 			REQUIRE(data->size() == data->m_durations.size());

--- a/tests/Filters/main.cpp
+++ b/tests/Filters/main.cpp
@@ -38,6 +38,7 @@
 #include <catch2/catch_all.hpp>
 #else
 #include <catch2/catch.hpp>
+#define EventListenerBase TestEventListenerBase
 #endif
 #include "Filters.h"
 

--- a/tests/Filters/main.cpp
+++ b/tests/Filters/main.cpp
@@ -48,11 +48,13 @@ minstd_rand g_rng;
 MockOscilloscope* g_scope;
 
 // Global initialization
-class testRunListener : public Catch::EventListenerBase {
+class testRunListener : public Catch::EventListenerBase
+{
 public:
     using Catch::EventListenerBase::EventListenerBase;
 
-    void testRunStarting(Catch::TestRunInfo const&) override {
+    void testRunStarting(Catch::TestRunInfo const&) override
+    {
 		g_log_sinks.emplace(g_log_sinks.begin(), new ColoredSTDLogSink(Severity::VERBOSE));
 
 		if(!VulkanInit())
@@ -83,7 +85,8 @@ public:
 	}
 
 	//Clean up after the scope goes out of scope (pun not intended)
-	void testRunEnded(Catch::TestRunStats const& testRunStats) override {
+	void testRunEnded(Catch::TestRunStats const& testRunStats) override
+	{
 		delete g_scope;
 		ScopehalStaticCleanup();
 	}

--- a/tests/Filters/main.cpp
+++ b/tests/Filters/main.cpp
@@ -46,45 +46,52 @@ using namespace std;
 minstd_rand g_rng;
 MockOscilloscope* g_scope;
 
-int main(int argc, char* argv[])
-{
-	g_log_sinks.emplace(g_log_sinks.begin(), new ColoredSTDLogSink(Severity::VERBOSE));
+// Global initialization
+class testRunListener : public Catch::EventListenerBase {
+public:
+    using Catch::EventListenerBase::EventListenerBase;
 
-	//Global scopehal initialization
-	VulkanInit();
-	TransportStaticInit();
-	DriverStaticInit();
-	InitializePlugins();
-	ScopeProtocolStaticInit();
+    void testRunStarting(Catch::TestRunInfo const&) override {
+		g_log_sinks.emplace(g_log_sinks.begin(), new ColoredSTDLogSink(Severity::VERBOSE));
 
-	//Add search path
-	g_searchPaths.push_back(GetDirOfCurrentExecutable() + "/../../src/ngscopeclient/");
+		if(!VulkanInit())
+			exit(1);
+		TransportStaticInit();
+		DriverStaticInit();
+		InitializePlugins();
+		ScopeProtocolStaticInit();
 
-	//Initialize the RNG
-	g_rng.seed(0);
+		//Add search path
+		g_searchPaths.push_back(GetDirOfCurrentExecutable() + "/../../src/ngscopeclient/");
 
-	int ret;
-	{
+		//Initialize the RNG
+		g_rng.seed(0);
+
 		//Create some fake scope channels
-		MockOscilloscope scope("Test Scope", "Antikernel Labs", "12345", "null", "mock", "");
-		scope.AddChannel(new OscilloscopeChannel(
-			&scope, "CH1", "#ffffffff", Unit(Unit::UNIT_FS), Unit(Unit::UNIT_VOLTS)));
-		scope.AddChannel(new OscilloscopeChannel(
-			&scope, "CH2", "#ffffffff", Unit(Unit::UNIT_FS), Unit(Unit::UNIT_VOLTS)));
+		g_scope = new MockOscilloscope("Test Scope", "Antikernel Labs", "12345", "null", "mock", "");
+		g_scope->AddChannel(new OscilloscopeChannel(
+			g_scope, "CH1", "#ffffffff", Unit(Unit::UNIT_FS), Unit(Unit::UNIT_VOLTS)));
+		g_scope->AddChannel(new OscilloscopeChannel(
+			g_scope, "CH2", "#ffffffff", Unit(Unit::UNIT_FS), Unit(Unit::UNIT_VOLTS)));
 
-		scope.AddChannel(new OscilloscopeChannel(
-			&scope, "Mag", "#ffffffff", Unit(Unit::UNIT_HZ), Unit(Unit::UNIT_DB)));
-		scope.AddChannel(new OscilloscopeChannel(
-			&scope, "Angle", "#ffffffff", Unit(Unit::UNIT_HZ), Unit(Unit::UNIT_DEGREES)));
-		g_scope = &scope;
+		g_scope->AddChannel(new OscilloscopeChannel(
+			g_scope, "Mag", "#ffffffff", Unit(Unit::UNIT_HZ), Unit(Unit::UNIT_DB)));
+		g_scope->AddChannel(new OscilloscopeChannel(
+			g_scope, "Angle", "#ffffffff", Unit(Unit::UNIT_HZ), Unit(Unit::UNIT_DEGREES)));
 
-		//Run the actual test
-		ret = Catch::Session().run(argc, argv);
 	}
 
-	//Clean up and return after the scope goes out of scope (pun not intended)
-	ScopehalStaticCleanup();
-	return ret;
+	//Clean up after the scope goes out of scope (pun not intended)
+	void testRunEnded(Catch::TestRunStats const& testRunStats) override {
+		delete g_scope;
+		ScopehalStaticCleanup();
+	}
+};
+CATCH_REGISTER_LISTENER(testRunListener)
+
+int main(int argc, char* argv[])
+{
+	return Catch::Session().run(argc, argv);
 }
 
 /**

--- a/tests/Primitives/main.cpp
+++ b/tests/Primitives/main.cpp
@@ -38,6 +38,7 @@
 #include <catch2/catch_all.hpp>
 #else
 #include <catch2/catch.hpp>
+#define EventListenerBase TestEventListenerBase
 #endif
 #include "Primitives.h"
 

--- a/tests/Primitives/main.cpp
+++ b/tests/Primitives/main.cpp
@@ -47,11 +47,13 @@ using namespace std;
 mt19937 g_rng;
 
 // Global initialization
-class testRunListener : public Catch::EventListenerBase {
+class testRunListener : public Catch::EventListenerBase
+{
 public:
     using Catch::EventListenerBase::EventListenerBase;
 
-    void testRunStarting(Catch::TestRunInfo const&) override {
+    void testRunStarting(Catch::TestRunInfo const&) override
+    {
 		g_log_sinks.emplace(g_log_sinks.begin(), new ColoredSTDLogSink(Severity::VERBOSE));
 
 		if(!VulkanInit())
@@ -67,7 +69,8 @@ public:
 		g_rng.seed(0);
 	}
 
-    void testRunEnded(Catch::TestRunStats const& testRunStats) override {
+    void testRunEnded(Catch::TestRunStats const& testRunStats) override
+    {
 		ScopehalStaticCleanup();
 	}
 };


### PR DESCRIPTION
This fixes #488.

Note that this may no longer be accurate:
```
//Clean up after the scope goes out of scope (pun not intended)
```