### PR TITLE
Prevent glfw init for tests as glfw requires an X/Wayland server

### DIFF
--- a/tests/Acceleration/main.cpp
+++ b/tests/Acceleration/main.cpp
@@ -56,7 +56,7 @@ public:
     {
 		g_log_sinks.emplace(g_log_sinks.begin(), new ColoredSTDLogSink(Severity::VERBOSE));
 
-		if(!VulkanInit())
+		if(!VulkanInit(true))
 			exit(1);
 		TransportStaticInit();
 		DriverStaticInit();

--- a/tests/Filters/main.cpp
+++ b/tests/Filters/main.cpp
@@ -57,7 +57,7 @@ public:
     {
 		g_log_sinks.emplace(g_log_sinks.begin(), new ColoredSTDLogSink(Severity::VERBOSE));
 
-		if(!VulkanInit())
+		if(!VulkanInit(true))
 			exit(1);
 		TransportStaticInit();
 		DriverStaticInit();

--- a/tests/Primitives/main.cpp
+++ b/tests/Primitives/main.cpp
@@ -56,7 +56,7 @@ public:
     {
 		g_log_sinks.emplace(g_log_sinks.begin(), new ColoredSTDLogSink(Severity::VERBOSE));
 
-		if(!VulkanInit())
+		if(!VulkanInit(true))
 			exit(1);
 		TransportStaticInit();
 		DriverStaticInit();


### PR DESCRIPTION
This allows for tests to function headless as they only require Vulkan compute, not a window.