### PR TITLE
Fix build with SANITIZE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,8 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 if(SANITIZE)
-	add_compile_options(-fsanitize=memory -fsanitize=thread -fsanitize=address -fsanitize=undefined -fsanitize=cfi -flto)
+	add_compile_options(-fsanitize=address -fsanitize=undefined)
+	add_link_options(-fsanitize=address -fsanitize=undefined)
 endif()
 
 if(WIN32)


### PR DESCRIPTION
Trying to enable all the sanitizers is silly and won't work. This just enables AddressSanitizer and UBSan, which can be used together on GCC and Clang.