### PR TITLE
Fix warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,17 @@
 cmake_minimum_required(VERSION 3.20)
 include_directories(cmake) #WORKAROUND needed for find_package(Vulkan) for Vulkan SDK
+enable_language(CXX)
 
-#WORKAROUND: Vulkan SDK is incompatible with MinGW due to C++ linkage
-
+# Warn if platform is not 64-bit
+if(NOT (CMAKE_SIZEOF_VOID_P EQUAL 8))
+	message(WARNING "You are attempting to build on a 32-bit platform. While this may work and we may accept fixes "
+		              "upstream, it will most likely fail and is unsupported.")
+endif()
 
 # Check for Vulkan SDK env var and prepend it to CMAKE_PREFIX_PATH if set to prefer Vulkan SDK packages if available
 if(DEFINED ENV{VULKAN_SDK})
-	if(WIN32 AND (NOT MSVC))
+	#WORKAROUND: Vulkan SDK is incompatible with MinGW due to C++ linkage
+	if(WIN32 AND (NOT CMAKE_GENERATOR MATCHES "Visual Studio"))
 		message(WARNING "Detected VULKAN_SDK at $ENV{VULKAN_SDK}.")
 		message(WARNING "Compiling and linking against the Vulkan SDK is not supported with MSYS. The build system "
 			      "will ignore the SDK and you will need to have the Vulkan packages installed from the MSYS repositories.")
@@ -40,7 +45,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"
 	add_compile_options(-Wall -Wextra -Wuninitialized)
 	add_compile_options(-Wshadow -Wpedantic -Wcast-align -Wwrite-strings)
 	add_compile_options(-Wmissing-declarations -Wvla)
-    add_compile_options(-Werror -Wno-error=deprecated-declarations -Wno-error=unused-parameter -Wno-error=unused-variable -Wno-error=unused-result)
+  add_compile_options(-Werror -Wno-error=deprecated-declarations -Wno-error=unused-parameter -Wno-error=unused-variable -Wno-error=unused-result)
 endif()
 
 # Compiler warnings specific to GCC or Clang
@@ -52,6 +57,11 @@ endif()
 add_compile_options(-g -mtune=native)
 add_compile_options("$<$<CONFIG:RELEASE>:-O3>")
 add_compile_options("$<$<CONFIG:DEBUG>:-O0;-D_DEBUG>")
+
+# Needed for %zu/%zd on MSYS2, must be added here to avoid redefinition
+if(WIN32 AND (NOT MSVC))
+    add_compile_definitions(__USE_MINGW_ANSI_STDIO=1)
+endif()
 
 # Default build type
 if(NOT CMAKE_BUILD_TYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include_directories(cmake) #WORKAROUND needed for find_package(Vulkan) for Vulka
 if(DEFINED ENV{VULKAN_SDK})
 	if(WIN32 AND (NOT MSVC))
 		message(WARNING "Detected VULKAN_SDK at $ENV{VULKAN_SDK}.")
-		message(WARNING "Compiling and linking against the Vulkan SDK is not supported with MSYS. The build system"
+		message(WARNING "Compiling and linking against the Vulkan SDK is not supported with MSYS. The build system "
 			      "will ignore the SDK and you will need to have the Vulkan packages installed from the MSYS repositories.")
 	else()
 		message("Detected and using VULKAN_SDK at $ENV{VULKAN_SDK}")
@@ -35,15 +35,19 @@ if(DISABLE_PCH)
 	set(CMAKE_DISABLE_PRECOMPILE_HEADERS ON)
 endif()
 
-# Compiler flags
-add_compile_options(-Wall -Wextra -Wuninitialized)
-add_compile_options(-Wshadow -Wpedantic -Wcast-align -Wwrite-strings)
-add_compile_options(-Wmissing-declarations -Wvla)
+# Compiler warnings for GCC/Clang
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+	add_compile_options(-Wall -Wextra -Wuninitialized)
+	add_compile_options(-Wshadow -Wpedantic -Wcast-align -Wwrite-strings)
+	add_compile_options(-Wmissing-declarations -Wvla)
+    add_compile_options(-Werror -Wno-error=deprecated-declarations -Wno-error=unused-parameter -Wno-error=unused-variable -Wno-error=unused-result)
+endif()
 
-# Compiler warnings
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-  add_compile_options(-Wpointer-sign -Wno-gnu-zero-variadic-macro-arguments -Wno-unknown-warning-option)
+# Compiler warnings specific to GCC or Clang
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13)
+	add_compile_options(-Woverloaded-virtual=1)
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Woverloaded-virtual -Wpointer-sign -Wno-gnu-zero-variadic-macro-arguments -Wno-unknown-warning-option)
 endif()
 add_compile_options(-g -mtune=native)
 add_compile_options("$<$<CONFIG:RELEASE>:-O3>")

--- a/src/ngscopeclient/AboutDialog.cpp
+++ b/src/ngscopeclient/AboutDialog.cpp
@@ -37,7 +37,7 @@
 #include "AboutDialog.h"
 #include "MainWindow.h"
 #include <ngscopeclient-version.h>
-#include "../imgui_markdown/imgui_markdown.h"
+#include <imgui_markdown.h>
 
 using namespace std;
 

--- a/src/ngscopeclient/BERTDialog.cpp
+++ b/src/ngscopeclient/BERTDialog.cpp
@@ -36,6 +36,8 @@
 #include "ngscopeclient.h"
 #include "BERTDialog.h"
 
+#include <cinttypes>
+
 using namespace std;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -128,7 +130,7 @@ bool BERTDialog::DoRender()
 			ImGui::SetNextItemWidth(width);
 			if(ImGui::InputText("Custom Pattern", &m_txPatternText))
 			{
-				sscanf(m_txPatternText.c_str(), "%lx", &m_txPattern);
+				sscanf(m_txPatternText.c_str(), "%" PRIx64, &m_txPattern);
 				m_bert->SetGlobalCustomPattern(m_txPattern);
 				m_refclkFrequency = m_bert->GetRefclkOutFrequency();
 			}

--- a/src/ngscopeclient/CMakeLists.txt
+++ b/src/ngscopeclient/CMakeLists.txt
@@ -174,9 +174,12 @@ endif()
 target_include_directories(ngscopeclient
 	PRIVATE
 	${CMAKE_CURRENT_BINARY_DIR}
-	SYSTEM
+	)
+target_include_directories(ngscopeclient
+	SYSTEM PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}/../imgui/
 	${CMAKE_CURRENT_SOURCE_DIR}/../imgui/misc/cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/../imgui_markdown
 	${CMAKE_CURRENT_SOURCE_DIR}/../implot/
 	${CMAKE_CURRENT_SOURCE_DIR}/../imgui-node-editor/
 	${CMAKE_CURRENT_SOURCE_DIR}/../ImGuiFileDialog/

--- a/src/ngscopeclient/CMakeLists.txt
+++ b/src/ngscopeclient/CMakeLists.txt
@@ -194,6 +194,14 @@ target_link_libraries(ngscopeclient
 	PNG::PNG
 	)
 
+if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+	target_compile_definitions(ngscopeclient
+		PRIVATE
+		ImTextureID=ImU64
+		VULKAN_HPP_TYPESAFE_CONVERSION=1
+	)
+endif()
+
 #Needed to run from tree without install because Windows does not support RPATH and will otherwise not be able to find DLLs
 if(WIN32)
 add_custom_command(TARGET ngscopeclient POST_BUILD

--- a/src/ngscopeclient/LoadDialog.cpp
+++ b/src/ngscopeclient/LoadDialog.cpp
@@ -78,7 +78,7 @@ void LoadDialog::RefreshFromHardware()
 		//Add placeholders for non-power channels
 		//TODO: can we avoid spawning a thread here pointlessly?
 		if( (m_load->GetInstrumentTypesForChannel(i) & Instrument::INST_LOAD) == 0)
-			m_futureUIState.push_back(async(launch::async, [load, i]{ LoadChannelUIState dummy; return dummy; }));
+			m_futureUIState.push_back(async(launch::async, [/*load, i*/]{ LoadChannelUIState dummy; return dummy; }));
 
 		//Actual power channels get async load
 		else

--- a/src/ngscopeclient/MainWindow.cpp
+++ b/src/ngscopeclient/MainWindow.cpp
@@ -77,7 +77,7 @@
 #include "TimebasePropertiesDialog.h"
 #include "TriggerPropertiesDialog.h"
 
-#include "../imgui_markdown/imgui_markdown.h"
+#include <imgui_markdown.h>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -139,7 +139,7 @@ MainWindow::MainWindow(shared_ptr<QueueHandle> queue)
 
 	vk::CommandBufferAllocateInfo bufinfo(**m_cmdPool, vk::CommandBufferLevel::ePrimary, 1);
 	m_cmdBuffer = make_unique<vk::raii::CommandBuffer>(
-		move(vk::raii::CommandBuffers(*g_vkComputeDevice, bufinfo).front()));
+		std::move(vk::raii::CommandBuffers(*g_vkComputeDevice, bufinfo).front()));
 
 	if(g_hasDebugUtils)
 	{

--- a/src/ngscopeclient/MainWindow.cpp
+++ b/src/ngscopeclient/MainWindow.cpp
@@ -82,14 +82,14 @@
 #ifdef _WIN32
 #include <windows.h>
 #include <shlwapi.h>
-#include <sys/stat.h>
 #else
-#include <sys/stat.h>
 #include <sys/types.h>
 #include <fcntl.h>
 #include <sys/mman.h>
 #endif
 
+#include <sys/stat.h>
+#include <cinttypes>
 
 using namespace std;
 
@@ -146,7 +146,7 @@ MainWindow::MainWindow(shared_ptr<QueueHandle> queue)
 		g_vkComputeDevice->setDebugUtilsObjectNameEXT(
 			vk::DebugUtilsObjectNameInfoEXT(
 				vk::ObjectType::eCommandPool,
-				reinterpret_cast<int64_t>(static_cast<VkCommandPool>(**m_cmdPool)),
+				reinterpret_cast<uint64_t>(static_cast<VkCommandPool>(**m_cmdPool)),
 				"MainWindow.m_cmdPool"));
 
 		g_vkComputeDevice->setDebugUtilsObjectNameEXT(
@@ -1322,7 +1322,7 @@ void MainWindow::LoadRecentInstrumentList()
 		for(auto it : node)
 		{
 			auto inst = it.second;
-			m_recentInstruments[inst["path"].as<string>()] = inst["timestamp"].as<long long>();
+			m_recentInstruments[inst["path"].as<string>()] = inst["timestamp"].as<int64_t>();
 		}
 	}
 	catch(const YAML::BadFile& ex)
@@ -1345,7 +1345,7 @@ void MainWindow::SaveRecentInstrumentList()
 		auto nick = it.first.substr(0, it.first.find(":"));
 		fprintf(fp, "%s:\n", nick.c_str());
 		fprintf(fp, "    path: \"%s\"\n", it.first.c_str());
-		fprintf(fp, "    timestamp: %ld\n", it.second);
+		fprintf(fp, "    timestamp: %" PRId64 "\n", static_cast<int64_t>(it.second));
 	}
 
 	fclose(fp);

--- a/src/ngscopeclient/NotesDialog.cpp
+++ b/src/ngscopeclient/NotesDialog.cpp
@@ -36,7 +36,7 @@
 #include "ngscopeclient.h"
 #include "NotesDialog.h"
 #include "MainWindow.h"
-#include "../imgui_markdown/imgui_markdown.h"
+#include <imgui_markdown.h>
 
 using namespace std;
 

--- a/src/ngscopeclient/PowerSupplyDialog.cpp
+++ b/src/ngscopeclient/PowerSupplyDialog.cpp
@@ -83,7 +83,7 @@ void PowerSupplyDialog::AsyncLoadState()
 		//Add placeholders for non-power channels
 		//TODO: can we avoid spawning a thread here pointlessly?
 		if( (m_psu->GetInstrumentTypesForChannel(i) & Instrument::INST_PSU) == 0)
-			m_futureUIState.push_back(async(launch::async, [psu, i]{ PowerSupplyChannelUIState dummy; return dummy; }));
+			m_futureUIState.push_back(async(launch::async, [/*psu, i*/]{ PowerSupplyChannelUIState dummy; return dummy; }));
 
 		//Actual power channels get async load
 		else

--- a/src/ngscopeclient/Preference.cpp
+++ b/src/ngscopeclient/Preference.cpp
@@ -43,7 +43,7 @@ using namespace std;
 namespace impl
 {
 	PreferenceBuilder::PreferenceBuilder(Preference&& pref)
-		: m_pref{move(pref)}
+		: m_pref{std::move(pref)}
 	{
 
 	}
@@ -51,30 +51,30 @@ namespace impl
 	PreferenceBuilder PreferenceBuilder::Invisible() &&
 	{
 		this->m_pref.m_isVisible = false;
-		return move(*this);
+		return std::move(*this);
 	}
 
 	PreferenceBuilder PreferenceBuilder::Label(std::string label) &&
 	{
 		this->m_pref.m_label = std::move(label);
-		return move(*this);
+		return std::move(*this);
 	}
 
 	PreferenceBuilder PreferenceBuilder::Description(std::string description) &&
 	{
 		this->m_pref.m_description = std::move(description);
-		return move(*this);
+		return std::move(*this);
 	}
 
 	PreferenceBuilder PreferenceBuilder::Unit(Unit::UnitType type) &&
 	{
 		this->m_pref.m_unit = ::Unit{ type };
-		return move(*this);
+		return std::move(*this);
 	}
 
 	Preference PreferenceBuilder::Build() &&
 	{
-		return move(this->m_pref);
+		return std::move(this->m_pref);
 	}
 }
 
@@ -261,13 +261,13 @@ string Preference::ToString() const
 void Preference::MoveFrom(Preference& other)
 {
 	m_type = other.m_type;
-	m_identifier = move(other.m_identifier);
-	m_description = move(other.m_description);
-	m_label = move(other.m_label);
-	m_isVisible = move(other.m_isVisible);
-	m_unit = move(other.m_unit);
-	m_hasValue = move(other.m_hasValue);
-	m_mapping = move(other.m_mapping);
+	m_identifier = std::move(other.m_identifier);
+	m_description = std::move(other.m_description);
+	m_label = std::move(other.m_label);
+	m_isVisible = std::move(other.m_isVisible);
+	m_unit = std::move(other.m_unit);
+	m_hasValue = std::move(other.m_hasValue);
+	m_mapping = std::move(other.m_mapping);
 
 	if(m_hasValue)
 	{
@@ -282,20 +282,20 @@ void Preference::MoveFrom(Preference& other)
 				break;
 
 			case PreferenceType::String:
-				Construct<string>(move(other.GetValueRaw<string>()));
+				Construct<string>(other.GetValueRaw<string>());
 				break;
 
 			case PreferenceType::Font:
-				Construct<FontDescription>(move(other.GetFont()));
+				Construct<FontDescription>(other.GetFont());
 				break;
 
 			case PreferenceType::Color:
-				Construct<impl::Color>(move(other.GetValueRaw<impl::Color>()));
+				Construct<impl::Color>(other.GetValueRaw<impl::Color>());
 				break;
 
 			case PreferenceType::Enum:
 			case PreferenceType::Int:
-				Construct<std::int64_t>(move(other.GetValueRaw<std::int64_t>()));
+				Construct<std::int64_t>(other.GetValueRaw<std::int64_t>());
 				break;
 
 			default:
@@ -355,7 +355,7 @@ void Preference::SetEnumRaw(std::int64_t value)
 void Preference::SetString(string value)
 {
 	CleanUp();
-	Construct<string>(move(value));
+	Construct<string>(value);
 }
 
 void Preference::SetColor(const ImU32& color)
@@ -370,7 +370,7 @@ void Preference::SetColor(const ImU32& color)
 		static_cast<uint8_t>((color >> IM_COL32_A_SHIFT) & 0xff)
 	};
 
-	Construct<impl::Color>(move(clr));
+	Construct<impl::Color>(clr);
 }
 
 void Preference::SetColorRaw(const impl::Color& color)
@@ -444,7 +444,7 @@ impl::PreferenceBuilder Preference::EnumRaw(std::string identifier, std::int64_t
 impl::PreferenceBuilder Preference::Font(std::string identifier, FontDescription defaultValue)
 {
 	Preference pref(PreferenceType::Font, std::move(identifier));
-	pref.Construct<FontDescription>(std::move(defaultValue));
+	pref.Construct<FontDescription>(defaultValue);
 
 	return impl::PreferenceBuilder{ std::move(pref) };
 }

--- a/src/ngscopeclient/PreferenceManager.cpp
+++ b/src/ngscopeclient/PreferenceManager.cpp
@@ -27,6 +27,9 @@
 *                                                                                                                      *
 ***********************************************************************************************************************/
 
+#include "ngscopeclient.h"
+#include "PreferenceManager.h"
+
 #include <fstream>
 #include <stdexcept>
 
@@ -38,9 +41,6 @@
 #include <sys/stat.h>
 #include <wordexp.h>
 #endif
-
-#include "ngscopeclient.h"
-#include "PreferenceManager.h"
 
 using namespace std;
 

--- a/src/ngscopeclient/PreferenceTree.cpp
+++ b/src/ngscopeclient/PreferenceTree.cpp
@@ -61,7 +61,7 @@ namespace internal
 	}
 
 	PreferencePath::PreferencePath(vector<string> segments)
-		: m_segments{ move(segments) }
+		: m_segments{ std::move(segments) }
 	{
 
 	}
@@ -69,7 +69,7 @@ namespace internal
 	PreferencePath PreferencePath::NextLevel() const
 	{
 		vector<string> newSegments{ next(this->m_segments.begin()), this->m_segments.end() };
-		return PreferencePath{ move(newSegments) };
+		return PreferencePath{ std::move(newSegments) };
 	}
 
 	size_t PreferencePath::GetLength() const
@@ -122,7 +122,7 @@ namespace internal
 	}
 
 	PreferenceHolder::PreferenceHolder(Preference pref)
-		: PreferenceTreeNodeBase(PreferenceTreeNodeType::Preference, pref.GetIdentifier()), m_pref{ move(pref) }
+		: PreferenceTreeNodeBase(PreferenceTreeNodeType::Preference, pref.GetIdentifier()), m_pref{ std::move(pref) }
 	{
 
 	}
@@ -327,7 +327,7 @@ void PreferenceCategory::FromYAML(const YAML::Node& node)
 }
 
 PreferenceCategory::PreferenceCategory(string identifier)
-	: PreferenceTreeNodeBase(PreferenceTreeNodeType::Category, move(identifier))
+	: PreferenceTreeNodeBase(PreferenceTreeNodeType::Category, std::move(identifier))
 {
 
 }
@@ -344,8 +344,8 @@ void PreferenceCategory::AddPreference(Preference pref)
 		throw runtime_error("Preference category already contains child with given name");
 
 	const auto identifier = pref.GetIdentifier();
-	unique_ptr<internal::PreferenceTreeNodeBase> ptr{ new internal::PreferenceHolder{ move(pref) } };
-	this->m_children[identifier] = move(ptr);
+	unique_ptr<internal::PreferenceTreeNodeBase> ptr{ new internal::PreferenceHolder{ std::move(pref) } };
+	this->m_children[identifier] = std::move(ptr);
 	this->m_ordering.push_back(identifier);
 }
 
@@ -360,7 +360,7 @@ PreferenceCategory& PreferenceCategory::AddCategory(string identifier)
 		throw runtime_error("Preference category already contains child with given name");
 
 	unique_ptr<internal::PreferenceTreeNodeBase> ptr{ new PreferenceCategory{ identifier } };
-	this->m_children[identifier] = move(ptr);
+	this->m_children[identifier] = std::move(ptr);
 	this->m_ordering.push_back(identifier);
 
 	return *static_cast<PreferenceCategory*>(this->m_children[identifier].get());

--- a/src/ngscopeclient/ScopeDeskewWizard.cpp
+++ b/src/ngscopeclient/ScopeDeskewWizard.cpp
@@ -37,6 +37,8 @@
 #include "ScopeDeskewWizard.h"
 #include "MainWindow.h"
 
+#include <cinttypes>
+
 using namespace std;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -85,7 +87,7 @@ ScopeDeskewWizard::ScopeDeskewWizard(
 		vk::CommandPoolCreateInfo(
 			vk::CommandPoolCreateFlagBits::eTransient | vk::CommandPoolCreateFlagBits::eResetCommandBuffer,
 			m_queue->m_family ))
-	, m_cmdBuf(move(vk::raii::CommandBuffers(*g_vkComputeDevice,
+	, m_cmdBuf(std::move(vk::raii::CommandBuffers(*g_vkComputeDevice,
 		vk::CommandBufferAllocateInfo(*m_pool, vk::CommandBufferLevel::ePrimary, 1)).front()))
 	, m_corrOut("corrOut")
 {
@@ -579,7 +581,7 @@ void ScopeDeskewWizard::StartCorrelation()
 	//Collect the skew from this round
 	int64_t skew = m_bestCorrelationOffset * pri->m_timescale;
 	Unit fs(Unit::UNIT_FS);
-	LogTrace("Best correlation = %f (delta = %ld / %s)\n",
+	LogTrace("Bxest correlation = %f (delta = %" PRId64 " / %s)\n",
 		m_bestCorrelation, m_bestCorrelationOffset, fs.PrettyPrint(skew).c_str());
 
 	//If we got a correlation of zero (TODO: why would this be?) then retry

--- a/src/ngscopeclient/ScopeDeskewWizard.cpp
+++ b/src/ngscopeclient/ScopeDeskewWizard.cpp
@@ -105,7 +105,7 @@ ScopeDeskewWizard::ScopeDeskewWizard(
 		g_vkComputeDevice->setDebugUtilsObjectNameEXT(
 			vk::DebugUtilsObjectNameInfoEXT(
 				vk::ObjectType::eCommandPool,
-				reinterpret_cast<int64_t>(static_cast<VkCommandPool>(*m_pool)),
+				reinterpret_cast<uint64_t>(static_cast<VkCommandPool>(*m_pool)),
 				"ScopeDeskewWizard.pool"));
 
 		g_vkComputeDevice->setDebugUtilsObjectNameEXT(
@@ -803,7 +803,7 @@ void ScopeDeskewWizard::DoProcessWaveformUniformUnequalRate(UniformAnalogWavefor
 
 			//Skip secondary samples if the current secondary sample ends before the primary sample starts
 			bool done = false;
-			while( ((isecondary + 1) *	psec->m_timescale) < utarget)
+			while( static_cast<uint64_t>((isecondary + 1) *	psec->m_timescale) < utarget)
 			{
 				isecondary ++;
 

--- a/src/ngscopeclient/Session.cpp
+++ b/src/ngscopeclient/Session.cpp
@@ -43,11 +43,13 @@
 #include "MultimeterDialog.h"
 #include "PowerSupplyDialog.h"
 #include "RFGeneratorDialog.h"
-#include <fstream>
 
 #include "../scopehal/LeCroyOscilloscope.h"
 #include "../scopehal/MockOscilloscope.h"
 #include "../scopeprotocols/EyePattern.h"
+
+#include <fstream>
+#include <cinttypes>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -544,7 +546,7 @@ bool Session::LoadWaveformDataForScope(
 		auto hist = m_history.GetHistory(time);
 		if(hist && (hist->m_history.find(scope) != hist->m_history.end()))
 		{
-			LogWarning("Session contains duplicate data for time %ld.%ld, discarding\n", time.first, time.second);
+			LogWarning("Session contains duplicate data for time %ld.%" PRId64 ", discarding\n", time.first, time.second);
 			continue;
 		}
 

--- a/src/ngscopeclient/Session.cpp
+++ b/src/ngscopeclient/Session.cpp
@@ -546,7 +546,7 @@ bool Session::LoadWaveformDataForScope(
 		auto hist = m_history.GetHistory(time);
 		if(hist && (hist->m_history.find(scope) != hist->m_history.end()))
 		{
-			LogWarning("Session contains duplicate data for time %ld.%" PRId64 ", discarding\n", time.first, time.second);
+			LogWarning("Session contains duplicate data for time %" PRId64 ".%" PRId64 ", discarding\n", static_cast<int64_t>(time.first), time.second);
 			continue;
 		}
 

--- a/src/ngscopeclient/TextureManager.cpp
+++ b/src/ngscopeclient/TextureManager.cpp
@@ -300,7 +300,7 @@ TextureManager::TextureManager(shared_ptr<QueueHandle> queue)
 
 	vk::CommandBufferAllocateInfo bufinfo(**m_cmdPool, vk::CommandBufferLevel::ePrimary, 1);
 	m_cmdBuf = make_unique<vk::raii::CommandBuffer>(
-		move(vk::raii::CommandBuffers(*g_vkComputeDevice, bufinfo).front()));
+		std::move(vk::raii::CommandBuffers(*g_vkComputeDevice, bufinfo).front()));
 }
 
 TextureManager::~TextureManager()

--- a/src/ngscopeclient/TextureManager.cpp
+++ b/src/ngscopeclient/TextureManager.cpp
@@ -199,25 +199,25 @@ void Texture::SetName(const string& name)
 		g_vkComputeDevice->setDebugUtilsObjectNameEXT(
 			vk::DebugUtilsObjectNameInfoEXT(
 				vk::ObjectType::eDescriptorSet,
-				reinterpret_cast<int64_t>(m_texture),
+				reinterpret_cast<uint64_t>(m_texture),
 				texName.c_str()));
 
 		g_vkComputeDevice->setDebugUtilsObjectNameEXT(
 			vk::DebugUtilsObjectNameInfoEXT(
 				vk::ObjectType::eImage,
-				reinterpret_cast<int64_t>(static_cast<VkImage>(*m_image)),
+				reinterpret_cast<uint64_t>(static_cast<VkImage>(*m_image)),
 				imageName.c_str()));
 
 		g_vkComputeDevice->setDebugUtilsObjectNameEXT(
 			vk::DebugUtilsObjectNameInfoEXT(
 				vk::ObjectType::eImageView,
-				reinterpret_cast<int64_t>(static_cast<VkImageView>(**m_view)),
+				reinterpret_cast<uint64_t>(static_cast<VkImageView>(**m_view)),
 				viewName.c_str()));
 
 		g_vkComputeDevice->setDebugUtilsObjectNameEXT(
 			vk::DebugUtilsObjectNameInfoEXT(
 				vk::ObjectType::eDeviceMemory,
-				reinterpret_cast<int64_t>(static_cast<VkDeviceMemory>(**m_deviceMemory)),
+				reinterpret_cast<uint64_t>(static_cast<VkDeviceMemory>(**m_deviceMemory)),
 				memName.c_str()));
 	}
 }

--- a/src/ngscopeclient/VulkanWindow.cpp
+++ b/src/ngscopeclient/VulkanWindow.cpp
@@ -153,7 +153,7 @@ VulkanWindow::VulkanWindow(const string& title, shared_ptr<QueueHandle> queue)
 		m_renderCompleteSemaphores.push_back(make_unique<vk::raii::Semaphore>(*g_vkComputeDevice, sinfo));
 		m_fences.push_back(make_unique<vk::raii::Fence>(*g_vkComputeDevice, finfo));
 		m_cmdBuffers.push_back(make_unique<vk::raii::CommandBuffer>(
-			move(vk::raii::CommandBuffers(*g_vkComputeDevice, bufinfo).front())));
+			std::move(vk::raii::CommandBuffers(*g_vkComputeDevice, bufinfo).front())));
 	}
 
 	//Initialize ImGui
@@ -335,7 +335,7 @@ bool VulkanWindow::UpdateFramebuffer()
 	vk::Format surfaceFormat = static_cast<vk::Format>(format.format);
 
 	//Save old swapchain
-	unique_ptr<vk::raii::SwapchainKHR> oldSwapchain = move(m_swapchain);
+	unique_ptr<vk::raii::SwapchainKHR> oldSwapchain = std::move(m_swapchain);
 
 	//Makw the swapchain
 	vk::SwapchainKHR oldSwapchainIfValid = {};

--- a/src/ngscopeclient/VulkanWindow.cpp
+++ b/src/ngscopeclient/VulkanWindow.cpp
@@ -32,6 +32,7 @@
 	@author Andrew D. Zonenberg
 	@brief Implementation of VulkanWindow
  */
+
 #include "ngscopeclient.h"
 #include "TextureManager.h"
 #include "VulkanWindow.h"
@@ -212,7 +213,7 @@ VulkanWindow::VulkanWindow(const string& title, shared_ptr<QueueHandle> queue)
 		g_vkComputeDevice->setDebugUtilsObjectNameEXT(
 			vk::DebugUtilsObjectNameInfoEXT(
 				vk::ObjectType::eDescriptorPool,
-				reinterpret_cast<int64_t>(static_cast<VkDescriptorPool>(**m_imguiDescriptorPool)),
+				reinterpret_cast<uint64_t>(static_cast<VkDescriptorPool>(**m_imguiDescriptorPool)),
 				poolName.c_str()));
 
 		//Workaround for Mesa bug, see https://gitlab.freedesktop.org/mesa/mesa/-/issues/8596
@@ -226,14 +227,14 @@ VulkanWindow::VulkanWindow(const string& title, shared_ptr<QueueHandle> queue)
 			g_vkComputeDevice->setDebugUtilsObjectNameEXT(
 				vk::DebugUtilsObjectNameInfoEXT(
 					vk::ObjectType::eSurfaceKHR,
-					reinterpret_cast<int64_t>(static_cast<VkSurfaceKHR>(**m_surface)),
+					reinterpret_cast<uint64_t>(static_cast<VkSurfaceKHR>(**m_surface)),
 					surfName.c_str()));
 		}
 
 		g_vkComputeDevice->setDebugUtilsObjectNameEXT(
 			vk::DebugUtilsObjectNameInfoEXT(
 				vk::ObjectType::eCommandPool,
-				reinterpret_cast<int64_t>(static_cast<VkCommandPool>(**m_cmdPool)),
+				reinterpret_cast<uint64_t>(static_cast<VkCommandPool>(**m_cmdPool)),
 				rpName.c_str()));
 
 		for(size_t i=0; i<m_backBuffers.size(); i++)
@@ -246,25 +247,25 @@ VulkanWindow::VulkanWindow(const string& title, shared_ptr<QueueHandle> queue)
 			g_vkComputeDevice->setDebugUtilsObjectNameEXT(
 				vk::DebugUtilsObjectNameInfoEXT(
 					vk::ObjectType::eSemaphore,
-					reinterpret_cast<int64_t>(static_cast<VkSemaphore>(**m_imageAcquiredSemaphores[i])),
+					reinterpret_cast<uint64_t>(static_cast<VkSemaphore>(**m_imageAcquiredSemaphores[i])),
 					iaName.c_str()));
 
 			g_vkComputeDevice->setDebugUtilsObjectNameEXT(
 				vk::DebugUtilsObjectNameInfoEXT(
 					vk::ObjectType::eSemaphore,
-					reinterpret_cast<int64_t>(static_cast<VkSemaphore>(**m_renderCompleteSemaphores[i])),
+					reinterpret_cast<uint64_t>(static_cast<VkSemaphore>(**m_renderCompleteSemaphores[i])),
 					rcName.c_str()));
 
 			g_vkComputeDevice->setDebugUtilsObjectNameEXT(
 				vk::DebugUtilsObjectNameInfoEXT(
 					vk::ObjectType::eFence,
-					reinterpret_cast<int64_t>(static_cast<VkFence>(**m_fences[i])),
+					reinterpret_cast<uint64_t>(static_cast<VkFence>(**m_fences[i])),
 					fName.c_str()));
 
 			g_vkComputeDevice->setDebugUtilsObjectNameEXT(
 				vk::DebugUtilsObjectNameInfoEXT(
 					vk::ObjectType::eCommandBuffer,
-					reinterpret_cast<int64_t>(static_cast<VkCommandBuffer>(**m_cmdBuffers[i])),
+					reinterpret_cast<uint64_t>(static_cast<VkCommandBuffer>(**m_cmdBuffers[i])),
 					cbName.c_str()));
 		}
 	}

--- a/src/ngscopeclient/WaveformArea.cpp
+++ b/src/ngscopeclient/WaveformArea.cpp
@@ -557,8 +557,8 @@ bool WaveformArea::Render(int iArea, int numAreas, ImVec2 clientArea)
 
 	//Settings calculated by RenderGrid() then reused in RenderYAxis()
 	map<float, float> gridmap;
-	float vbot;
-	float vtop;
+	float vbot = 0.0f;
+	float vtop = 0.0f;
 
 	if(ImGui::BeginChild(ImGui::GetID(this), ImVec2(clientArea.x - yAxisWidthSpaced, unspacedHeightPerArea)))
 	{
@@ -2782,7 +2782,7 @@ void WaveformArea::DragDropOverlays(ImVec2 start, ImVec2 size, int iArea, int nu
 		CenterLeftDropArea(ImVec2(leftOfMiddle, topOfMiddle), ImVec2(widthOfMiddle/2, heightOfMiddle));
 
 	//Only show split in bottom (or top?) area
-	if( (iArea == (numAreas-1)) /*|| (iArea == 0)*/ )
+	if( iArea == (numAreas-1) /*|| (iArea == 0)*/ )
 		CenterRightDropArea(ImVec2(leftOfMiddle + widthOfMiddle/2, topOfMiddle), ImVec2(widthOfMiddle/2, heightOfMiddle));
 
 	ImVec2 edgeSize(widthOfVerticalEdge, heightOfMiddle);

--- a/src/ngscopeclient/WaveformThread.cpp
+++ b/src/ngscopeclient/WaveformThread.cpp
@@ -86,7 +86,7 @@ void WaveformThread(Session* session, atomic<bool>* shuttingDown)
 		g_vkComputeDevice->setDebugUtilsObjectNameEXT(
 			vk::DebugUtilsObjectNameInfoEXT(
 				vk::ObjectType::eCommandPool,
-				reinterpret_cast<int64_t>(static_cast<VkCommandPool>(*pool)),
+				reinterpret_cast<uint64_t>(static_cast<VkCommandPool>(*pool)),
 				poolname.c_str()));
 
 		g_vkComputeDevice->setDebugUtilsObjectNameEXT(

--- a/src/ngscopeclient/WaveformThread.cpp
+++ b/src/ngscopeclient/WaveformThread.cpp
@@ -75,7 +75,7 @@ void WaveformThread(Session* session, atomic<bool>* shuttingDown)
 	vk::raii::CommandPool pool(*g_vkComputeDevice, poolInfo);
 
 	vk::CommandBufferAllocateInfo bufinfo(*pool, vk::CommandBufferLevel::ePrimary, 1);
-	vk::raii::CommandBuffer cmdbuf(move(vk::raii::CommandBuffers(*g_vkComputeDevice, bufinfo).front()));
+	vk::raii::CommandBuffer cmdbuf(std::move(vk::raii::CommandBuffers(*g_vkComputeDevice, bufinfo).front()));
 
 	if(g_hasDebugUtils)
 	{

--- a/src/ngscopeclient/pthread_compat.cpp
+++ b/src/ngscopeclient/pthread_compat.cpp
@@ -27,7 +27,7 @@
 *                                                                                                                      *
 ***********************************************************************************************************************/
 
-#if defined(unix) || defined(__unix__) || defined(__unix)
+#if defined(unix) || defined(__unix__) || defined(__unix) || defined(__APPLE__)
 #include <pthread.h>
 #endif
 
@@ -35,7 +35,7 @@
 
 void pthread_setname_np_compat(const char *name)
 {
-#if defined(unix) || defined(__unix__) || defined(__unix)
+#if defined(unix) || defined(__unix__) || defined(__unix) || defined(__APPLE__)
 	#if __linux__
 		// on Linux, max 16 chars including \0, see man page
 		pthread_setname_np(pthread_self(), name);

--- a/tests/Acceleration/main.cpp
+++ b/tests/Acceleration/main.cpp
@@ -67,7 +67,7 @@ public:
 	}
 
 	//Clean up after the scope goes out of scope (pun not intended)
-    void testRunEnded(Catch::TestRunStats const& testRunStats) override
+    void testRunEnded([[maybe_unused]] Catch::TestRunStats const& testRunStats) override
     {
 		ScopehalStaticCleanup();
 	}

--- a/tests/Filters/Filter_Add.cpp
+++ b/tests/Filters/Filter_Add.cpp
@@ -62,7 +62,7 @@ TEST_CASE("Filter_Add")
 	vk::raii::CommandPool pool(*g_vkComputeDevice, poolInfo);
 
 	vk::CommandBufferAllocateInfo bufinfo(*pool, vk::CommandBufferLevel::ePrimary, 1);
-	vk::raii::CommandBuffer cmdbuf(move(vk::raii::CommandBuffers(*g_vkComputeDevice, bufinfo).front()));
+	vk::raii::CommandBuffer cmdbuf(std::move(vk::raii::CommandBuffers(*g_vkComputeDevice, bufinfo).front()));
 
 	//Create two empty input waveforms
 	const size_t depth = 10000000;

--- a/tests/Filters/Filter_DeEmbed.cpp
+++ b/tests/Filters/Filter_DeEmbed.cpp
@@ -63,7 +63,7 @@ TEST_CASE("Filter_DeEmbed")
 	vk::raii::CommandPool pool(*g_vkComputeDevice, poolInfo);
 
 	vk::CommandBufferAllocateInfo bufinfo(*pool, vk::CommandBufferLevel::ePrimary, 1);
-	vk::raii::CommandBuffer cmdbuf(move(vk::raii::CommandBuffers(*g_vkComputeDevice, bufinfo).front()));
+	vk::raii::CommandBuffer cmdbuf(std::move(vk::raii::CommandBuffers(*g_vkComputeDevice, bufinfo).front()));
 
 	//Create an empty input waveform
 	const size_t depth = 1000000;

--- a/tests/Filters/Filter_FFT.cpp
+++ b/tests/Filters/Filter_FFT.cpp
@@ -72,7 +72,7 @@ TEST_CASE("Filter_FFT")
 	vk::raii::CommandPool pool(*g_vkComputeDevice, poolInfo);
 
 	vk::CommandBufferAllocateInfo bufinfo(*pool, vk::CommandBufferLevel::ePrimary, 1);
-	vk::raii::CommandBuffer cmdbuf(move(vk::raii::CommandBuffers(*g_vkComputeDevice, bufinfo).front()));
+	vk::raii::CommandBuffer cmdbuf(std::move(vk::raii::CommandBuffers(*g_vkComputeDevice, bufinfo).front()));
 
 	//Create an empty input waveform
 	const size_t depth = 1000000;

--- a/tests/Filters/Filter_FIR.cpp
+++ b/tests/Filters/Filter_FIR.cpp
@@ -59,7 +59,7 @@ TEST_CASE("Filter_FIR")
 	vk::raii::CommandPool pool(*g_vkComputeDevice, poolInfo);
 
 	vk::CommandBufferAllocateInfo bufinfo(*pool, vk::CommandBufferLevel::ePrimary, 1);
-	vk::raii::CommandBuffer cmdbuf(move(vk::raii::CommandBuffers(*g_vkComputeDevice, bufinfo).front()));
+	vk::raii::CommandBuffer cmdbuf(std::move(vk::raii::CommandBuffers(*g_vkComputeDevice, bufinfo).front()));
 
 	//Create an empty input waveform
 	const size_t depth = 10000000;

--- a/tests/Filters/Filter_Subtract.cpp
+++ b/tests/Filters/Filter_Subtract.cpp
@@ -62,7 +62,7 @@ TEST_CASE("Filter_Subtract")
 	vk::raii::CommandPool pool(*g_vkComputeDevice, poolInfo);
 
 	vk::CommandBufferAllocateInfo bufinfo(*pool, vk::CommandBufferLevel::ePrimary, 1);
-	vk::raii::CommandBuffer cmdbuf(move(vk::raii::CommandBuffers(*g_vkComputeDevice, bufinfo).front()));
+	vk::raii::CommandBuffer cmdbuf(std::move(vk::raii::CommandBuffers(*g_vkComputeDevice, bufinfo).front()));
 
 	//Create two empty input waveforms
 	const size_t depth = 10000000;

--- a/tests/Filters/Filter_Upsample.cpp
+++ b/tests/Filters/Filter_Upsample.cpp
@@ -59,7 +59,7 @@ TEST_CASE("Filter_Upsample")
 	vk::raii::CommandPool pool(*g_vkComputeDevice, poolInfo);
 
 	vk::CommandBufferAllocateInfo bufinfo(*pool, vk::CommandBufferLevel::ePrimary, 1);
-	vk::raii::CommandBuffer cmdbuf(move(vk::raii::CommandBuffers(*g_vkComputeDevice, bufinfo).front()));
+	vk::raii::CommandBuffer cmdbuf(std::move(vk::raii::CommandBuffers(*g_vkComputeDevice, bufinfo).front()));
 
 	//Create an empty input waveform
 	const size_t depth = 10000000;

--- a/tests/Filters/main.cpp
+++ b/tests/Filters/main.cpp
@@ -85,7 +85,7 @@ public:
 	}
 
 	//Clean up after the scope goes out of scope (pun not intended)
-	void testRunEnded(Catch::TestRunStats const& testRunStats) override
+	void testRunEnded([[maybe_unused]] Catch::TestRunStats const& testRunStats) override
 	{
 		delete g_scope;
 		ScopehalStaticCleanup();

--- a/tests/Primitives/Convert16BitSamples.cpp
+++ b/tests/Primitives/Convert16BitSamples.cpp
@@ -61,7 +61,7 @@ TEST_CASE("Primitive_Convert16BitSamples")
 	vk::raii::CommandPool pool(*g_vkComputeDevice, poolInfo);
 
 	vk::CommandBufferAllocateInfo bufinfo(*pool, vk::CommandBufferLevel::ePrimary, 1);
-	vk::raii::CommandBuffer cmdbuf(move(vk::raii::CommandBuffers(*g_vkComputeDevice, bufinfo).front()));
+	vk::raii::CommandBuffer cmdbuf(std::move(vk::raii::CommandBuffers(*g_vkComputeDevice, bufinfo).front()));
 
 	AcceleratorBuffer<int16_t> data_in;
 	AcceleratorBuffer<float> data_out;

--- a/tests/Primitives/Convert8BitSamples.cpp
+++ b/tests/Primitives/Convert8BitSamples.cpp
@@ -59,7 +59,7 @@ TEST_CASE("Primitive_Convert8BitSamples")
 	vk::raii::CommandPool pool(*g_vkComputeDevice, poolInfo);
 
 	vk::CommandBufferAllocateInfo bufinfo(*pool, vk::CommandBufferLevel::ePrimary, 1);
-	vk::raii::CommandBuffer cmdbuf(move(vk::raii::CommandBuffers(*g_vkComputeDevice, bufinfo).front()));
+	vk::raii::CommandBuffer cmdbuf(std::move(vk::raii::CommandBuffers(*g_vkComputeDevice, bufinfo).front()));
 
 	AcceleratorBuffer<int8_t> data_in;
 	AcceleratorBuffer<float> data_out;

--- a/tests/Primitives/main.cpp
+++ b/tests/Primitives/main.cpp
@@ -69,7 +69,7 @@ public:
 		g_rng.seed(0);
 	}
 
-    void testRunEnded(Catch::TestRunStats const& testRunStats) override
+    void testRunEnded([[maybe_unused]] Catch::TestRunStats const& testRunStats) override
     {
 		ScopehalStaticCleanup();
 	}


### PR DESCRIPTION
This fixes nearly all current warnings. `[[maybe_unused]]` is added in some places where it makes sense. `-Werror` has been turned on for most warnings as well.

The related scopehal PR, https://github.com/ngscopeclient/scopehal/pull/854, and the related logtools PR, https://github.com/ngscopeclient/logtools/pull/14, are needed.