### PR TITLE
Update performance metrics window for unified memory

### DIFF
--- a/src/ngscopeclient/MetricsDialog.cpp
+++ b/src/ngscopeclient/MetricsDialog.cpp
@@ -223,10 +223,23 @@ bool MetricsDialog::DoRender()
 			auto pinnedUsage = membudget.heapUsage[g_vkPinnedMemoryHeap];
 			auto pinnedBudget = membudget.heapBudget[g_vkPinnedMemoryHeap];
 
-			auto localUsage = membudget.heapUsage[g_vkLocalMemoryHeap];
-			auto localBudget = membudget.heapBudget[g_vkLocalMemoryHeap];
+			std::string pinnedNodeName, pinnedHelpMarkerBudgetText, pinnedHelpMarkerUsageText;
+			if(g_vulkanDeviceHasUnifiedMemory) {
+				pinnedNodeName = "Unified";
+				pinnedHelpMarkerBudgetText = "Amount of unified RAM available for use by ngscopeclient.\n\n"
+					"This is your total RAM minus memory which is in use by the OS or other applications.";
+				pinnedHelpMarkerUsageText = "Amount of unified RAM currently in use by ngscopeclient.";
+			}
+			else {
+				pinnedNodeName = "Pinned";
+				pinnedHelpMarkerBudgetText = "Amount of pinned CPU-side RAM available for use by ngscopeclient.\n\n"
+					"This is your total RAM minus memory which cannot be pinned for PCIe access,\n"
+					"or is in use by the OS or other applications.";
+				pinnedHelpMarkerUsageText = "Amount of pinned CPU-side RAM currently in use by ngscopeclient.";
+			}
 
-			if(ImGui::TreeNodeEx("Pinned", ImGuiTreeNodeFlags_DefaultOpen))
+
+			if(ImGui::TreeNodeEx(pinnedNodeName.c_str(), ImGuiTreeNodeFlags_DefaultOpen))
 			{
 				ImGui::BeginDisabled();
 					str = bytes.PrettyPrint(pinnedBudget, 4);
@@ -234,10 +247,7 @@ bool MetricsDialog::DoRender()
 					ImGui::InputText("Budget", &str);
 				ImGui::EndDisabled();
 
-				HelpMarker(
-					"Amount of pinned CPU-side RAM available for use by ngscopeclient.\n\n"
-					"This is your total RAM minus memory which cannot be pinned for PCIe access,\n"
-					"or is in use by the OS or other applications.");
+				HelpMarker(pinnedHelpMarkerBudgetText);
 
 				ImGui::BeginDisabled();
 					str = bytes.PrettyPrint(pinnedUsage, 4) +
@@ -246,13 +256,16 @@ bool MetricsDialog::DoRender()
 					ImGui::InputText("Usage", &str);
 				ImGui::EndDisabled();
 
-				HelpMarker("Amount of pinned CPU-side RAM currently in use by ngscopeclient.");
+				HelpMarker(pinnedHelpMarkerUsageText);
 
 				ImGui::TreePop();
 			}
 
-			if(ImGui::TreeNodeEx("Local", ImGuiTreeNodeFlags_DefaultOpen))
+			if(!g_vulkanDeviceHasUnifiedMemory && ImGui::TreeNodeEx("Local", ImGuiTreeNodeFlags_DefaultOpen))
 			{
+				auto localUsage = membudget.heapUsage[g_vkLocalMemoryHeap];
+				auto localBudget = membudget.heapBudget[g_vkLocalMemoryHeap];
+
 				ImGui::BeginDisabled();
 					str = bytes.PrettyPrint(localBudget, 4);
 					ImGui::SetNextItemWidth(10 * ImGui::GetFontSize());

--- a/src/ngscopeclient/MetricsDialog.cpp
+++ b/src/ngscopeclient/MetricsDialog.cpp
@@ -274,8 +274,7 @@ bool MetricsDialog::DoRender()
 
 				HelpMarker(
 					"Amount of GPU-side RAM available for use by ngscopeclient.\n\n"
-					"This is your total video RAM minus memory which is in use by the OS or other applications.\n"
-					"For unified-memory systems, this is normally the same as your pinned memory budget."
+					"This is your total video RAM minus memory which is in use by the OS or other applications."
 					);
 
 				ImGui::BeginDisabled();


### PR DESCRIPTION
Updates the performance metrics window to accurately show usage with unified memory (requires https://github.com/ngscopeclient/scopehal/pull/860).