### PR TITLE
Fix for GPUs that have a swapchain shallower or deeper than 2 images

### DIFF
--- a/src/ngscopeclient/VulkanWindow.h
+++ b/src/ngscopeclient/VulkanWindow.h
@@ -146,6 +146,9 @@ protected:
 		std::vector<VkImage> m_backBuffers;
 	#endif
 
+	///@brief The minimum image count for the backbuffer allowed by this GPU
+	int m_minImageCount;
+
 	///@brief Current window width
 	int m_width;
 
@@ -172,6 +175,7 @@ protected:
 
 	///@brief Textures used this frame
 	std::vector< std::set<std::shared_ptr<Texture> > > m_texturesUsedThisFrame;
+
 };
 
 #endif


### PR DESCRIPTION
The Intel integrated GPU on my Ivy Bridge laptop has a minimum swapchain of 4 images. I've tested this on that computer as well as on my M2 MacBook Air and it works fine.