### PR TITLE
Nix flake for ngscopeclient

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1710451336,
+        "narHash": "sha256-pP86Pcfu3BrAvRO7R64x7hs+GaQrjFes+mEPowCfkxY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d691274a972b3165335d261cc4671335f5c67de9",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -38,8 +38,11 @@
       devShell = forAllSystems (system:
         let
           pkgs = nixpkgsFor.${system};
+          scopeHal = packages.${system}.scopehal-apps;
         in pkgs.mkShell {
-          buildInputs = [ packages.${system}.scopehal-apps ];
+          nativeBuildInputs = scopeHal.nativeBuildInputs;
+          buildInputs = scopeHal.buildInputs;
+          hardeningDisable = [ "all" ];
           shellHook = "echo Welcome to the ngscopeclient devShell!\n" + 
                       packages.${system}.libraryPaths;
         }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,48 @@
+{
+  description = "ngscopeclient";
+  nixConfig.bash-prompt = "[nix(ngscopeclient)] ";
+
+  # Nixpkgs / NixOS version to use.
+  inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  outputs = { nixpkgs, ... }:
+    let
+      # System types to support.
+      supportedSystems =
+        [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+
+      # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      # Nixpkgs instantiated for supported system types.
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+    in rec {
+      # Provide some binary packages for selected system types.
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+          inherit (pkgs) callPackage;
+          outPathOf = x: if (builtins.hasAttr "lib" x) 
+                         then x.lib.outPath
+                         else x.out.outPath;
+          libAppend = x: ''
+              export LD_LIBRARY_PATH="${outPathOf x}/lib:$LD_LIBRARY_PATH"
+              '';
+        in rec {
+          ffts = callPackage ./nix/ffts.nix { };
+          scopehal-apps = callPackage ./nix/scopehal-apps.nix { inherit ffts; };
+          default = scopehal-apps;
+          libraryPaths = builtins.concatStringsSep "" (map libAppend scopehal-apps.buildInputs);
+      });
+
+      devShell = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+        in pkgs.mkShell {
+          buildInputs = [ packages.${system}.scopehal-apps ];
+          shellHook = "echo Welcome to the ngscopeclient devShell!\n" + 
+                      packages.${system}.libraryPaths;
+        }
+      );
+    };
+}

--- a/nix/ffts.nix
+++ b/nix/ffts.nix
@@ -1,0 +1,30 @@
+{ stdenv, cmake, git, lib, fetchFromGitHub,
+  ... }:
+stdenv.mkDerivation rec {
+  pname = "ffts";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "anthonix";
+    repo = "ffts";
+    rev = "fe86885ecafd0d16eb122f3212403d1d5a86e24e";
+    hash = "sha256-arBXkEbKGd0y6XpyynUSFQmNs7fndhEK7y1NNZI9MnI=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake git ];
+  buildInputs = [  ];
+
+  cmakeFlags = [
+    "-DCURRENT_GIT_VERSION=${lib.substring 0 7 src.rev}"
+    "-DENABLE_SHARED=ON"
+    "-Wno-deprecated"
+  ];
+
+  meta = with lib; {
+    description = "The Fastest Fourier Transform in the South";
+    homepage = "http://anthonix.com/ffts";
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}

--- a/nix/scopehal-apps.nix
+++ b/nix/scopehal-apps.nix
@@ -13,8 +13,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "ngscopeclient";
     repo = "scopehal-apps";
-    rev = "b58983056b0b6a628c97e6fbf57be3cc010717d4";
-    hash = "sha256-PYl5qx6dGBfsDOGuQP7kPEh71skR3HPpX7YCVa+uhiY=";
+    rev = "33c7cddc344f2a7a337b8a3987e16e29f5dd4d0b";
+    hash = "sha256-kingCorT42tacCrnNEjRRjRREm9g+ju1Zab4xHBFmiI=";
     fetchSubmodules = true;
   };
 

--- a/nix/scopehal-apps.nix
+++ b/nix/scopehal-apps.nix
@@ -1,0 +1,76 @@
+{ stdenv, breakpointHook, fetchFromGitHub, makeWrapper,
+  cmake, git, lib, pkg-config,
+  libsigcxx, gtkmm3, cairomm, yaml-cpp, catch2, glfw, libtirpc, liblxi,
+  glew, libllvm, libdrm, elfutils, libxcb, zstd, libxshmfence, xcbutilkeysyms,
+  systemd,
+  shaderc, vulkan-headers, vulkan-loader, vulkan-tools, glslang, spirv-tools,
+  ffts,
+  ... }:
+stdenv.mkDerivation rec {
+  pname = "scopehal-apps";
+  version = "b589830";
+
+  src = fetchFromGitHub {
+    owner = "ngscopeclient";
+    repo = "scopehal-apps";
+    rev = "b58983056b0b6a628c97e6fbf57be3cc010717d4";
+    hash = "sha256-PYl5qx6dGBfsDOGuQP7kPEh71skR3HPpX7YCVa+uhiY=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake git makeWrapper ];
+  buildInputs = [
+    pkg-config
+    libsigcxx
+    gtkmm3
+    cairomm
+    yaml-cpp
+    catch2
+    glfw
+    libtirpc
+    liblxi
+    glew
+    libllvm
+    libdrm
+    elfutils
+    libxcb
+    zstd
+    libxshmfence
+    xcbutilkeysyms
+    systemd
+    vulkan-headers
+    vulkan-loader
+    vulkan-tools
+    spirv-tools
+    glslang
+    shaderc
+    ffts
+ ];
+
+  libraryPaths =
+    let
+      outPathOf = x: if (builtins.hasAttr "lib" x)
+                      then x.lib.outPath
+                      else x.out.outPath;
+      libAppend = x: "${outPathOf x}/lib";
+    in
+      builtins.concatStringsSep ":" (map libAppend buildInputs);
+
+  cmakeFlags = [
+    "-DCURRENT_GIT_VERSION=${lib.substring 0 7 src.rev}"
+    "-Wno-deprecated"
+  ];
+
+  postInstall = ''
+    ln -s $out/share $out/bin/
+    mv -v $out/bin/ngscopeclient $out/bin/ngscopeclient-unwrapped
+    makeWrapper $out/bin/ngscopeclient-unwrapped $out/bin/ngscopeclient --set LD_LIBRARY_PATH="${libraryPaths}"
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.ngscopeclient.org/";
+    license = licenses.bsd3;
+    maintainers = with lib.maintainers; [ thoughtpolice hansfbaier ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
With this flake compiling and installing ngscopeclient is a one liner
on any linux system that has the nix package manager installed:
```
nix shell github:ngscopeclient/scopehal-apps
```
or it can be permanently installed the user's profile with
```
nix profile install github:ngscopeclient/scopehal-apps
```
Tested working.
Or install the nix package manager and test it on your system.