### PR TITLE
Add horizontal scroll support for waveform views

### DIFF
--- a/src/ngscopeclient/WaveformArea.h
+++ b/src/ngscopeclient/WaveformArea.h
@@ -594,7 +594,7 @@ protected:
 	///@brief The stream currently being dragged (invalid if m_dragState != DRAG_STATE_CHANNEL)
 	StreamDescriptor m_dragStream;
 
-	void OnMouseWheelPlotArea(float delta);
+	void OnMouseWheelPlotArea(float delta, float delta_h);
 	void OnMouseWheelYAxis(float delta);
 	void OnMouseUp();
 	void OnDragUpdate();

--- a/src/ngscopeclient/WaveformGroup.cpp
+++ b/src/ngscopeclient/WaveformGroup.cpp
@@ -172,7 +172,7 @@ bool WaveformGroup::Render()
 
 	bool open = true;
 	ImGui::SetNextWindowSize(ImVec2(320, 240), ImGuiCond_Appearing);
-	if(!ImGui::Begin(GetID().c_str(), &open))
+	if(!ImGui::Begin(GetID().c_str(), &open, ImGuiWindowFlags_NoScrollWithMouse))
 	{
 		//tabbed out, don't draw anything until we're back in the foreground
 		ImGui::End();
@@ -1287,6 +1287,15 @@ void WaveformGroup::OnZoomOutHorizontal(int64_t target, float step)
 	//Change the zoom
 	m_pixelsPerXUnit /= step;
 	m_xAxisOffset = target - (delta*step);
+
+	ClearPersistence();
+}
+
+void WaveformGroup::OnPanHorizontal(float step)
+{
+	//TODO: Clamp to bounds of all waveforms in the group
+
+	m_xAxisOffset -=  PixelsToXAxisUnits(step * 100);
 
 	ClearPersistence();
 }

--- a/src/ngscopeclient/WaveformGroup.h
+++ b/src/ngscopeclient/WaveformGroup.h
@@ -70,6 +70,7 @@ public:
 
 	void OnZoomInHorizontal(int64_t target, float step);
 	void OnZoomOutHorizontal(int64_t target, float step);
+	void OnPanHorizontal(float step);
 	void NavigateToTimestamp(
 		int64_t timestamp,
 		int64_t duration = 0,


### PR DESCRIPTION
This PR adds support for horizontally scrolling through waveforms with a horizontal scroll wheel or Shift+Scroll.

Also:
- Replaces deprecated `ImGui::SetItemUsingMouseWheel` with `ImGui::SetItemKeyOwner(ImGuiKey_MouseWheelY/X)` 
- Adds `ImGuiWindowFlags_NoScrollWithMouse` flag to the WaveformGroup to  prevent buggy horizontal scroll behaviour