### PR TITLE
WIP: DPI scaling improvements

### DIFF
--- a/src/ngscopeclient/MainWindow.cpp
+++ b/src/ngscopeclient/MainWindow.cpp
@@ -1696,7 +1696,7 @@ void MainWindow::UpdateFonts()
 	//Check for any changes to font preferences and rebuild the atlas if so
 	//Skip rebuilding atlas if nothing changed
 	auto& prefs = GetSession().GetPreferences();
-	if(m_fontmgr.UpdateFonts(prefs.AllPreferences(), GetContentScale()))
+	if(m_fontmgr.UpdateFonts(prefs.AllPreferences(), GetUIScale() * GetFontScale()))
 	{
 		//Download imgui fonts
 		ImGui_ImplVulkan_CreateFontsTexture();

--- a/src/ngscopeclient/VulkanWindow.cpp
+++ b/src/ngscopeclient/VulkanWindow.cpp
@@ -181,17 +181,11 @@ VulkanWindow::VulkanWindow(const string& title, shared_ptr<QueueHandle> queue)
 		ImGui_ImplVulkan_Init(&info);
 	}
 
-	// Apply DPI scaling now that glfw initialized
-	float scale = GetContentScale();
+	float ui_scale = GetUIScale(), font_scale = GetFontScale();
+	LogTrace("UI scale: %.2f\n", ui_scale);
+	LogTrace("Text density: %.2f dpi = 96 dpi × %.2f (UI scale) × %.2f (font scale)\n", 96.0 * ui_scale * font_scale, ui_scale, font_scale);
 
-	LogTrace("Applying ImGui style scale factor: %.2f\n", scale);
-
-	//WORKAROUND: handle HiDPI correctly on macOS.
-#ifdef __APPLE__
-	io.FontGlobalScale = 1.0f / scale;
-#else
-	ImGui::GetStyle().ScaleAllSizes(scale);
-#endif
+	ImGui::GetStyle().ScaleAllSizes(ui_scale);
 
 	//Hook a couple of backend functions with mutexing
 	ImGuiPlatformIO& platform_io = ImGui::GetPlatformIO();
@@ -430,14 +424,37 @@ bool VulkanWindow::UpdateFramebuffer()
 	return true;
 }
 
-float VulkanWindow::GetContentScale()
+float VulkanWindow::GetUIScale()
 {
-	float xscale;
-	float yscale;
-	glfwGetWindowContentScale(m_window, &xscale, &yscale);
+	if (const char *scale_override = getenv("NGSCOPECLIENT_UI_SCALE"))
+		return atof(scale_override);
+#if defined(WIN32)
+	// FIXME
+#elif defined(__APPLE__)
+	// FIXME
+#else
+	// KDE also sets these variables.
+	if (const char *gdk_scale = getenv("GDK_SCALE"))
+		return atoi(gdk_scale);
+#endif
 
-	// Hope this works well should a screen have unequal X- and Y- DPIs...
-	return (xscale + yscale) / 2;
+	return 1.0;
+}
+
+float VulkanWindow::GetFontScale()
+{
+	if (const char *scale_override = getenv("NGSCOPECLIENT_FONT_SCALE"))
+		return atof(scale_override);
+#if defined(WIN32)
+	// FIXME
+#elif defined(__APPLE__)
+	// FIXME
+#else
+	// KDE also sets these variables.
+	if (const char *gdk_dpi_scale = getenv("GDK_DPI_SCALE"))
+		return atof(gdk_dpi_scale);
+#endif
+	return 1.0;
 }
 
 void VulkanWindow::Render()

--- a/src/ngscopeclient/VulkanWindow.h
+++ b/src/ngscopeclient/VulkanWindow.h
@@ -49,9 +49,11 @@ public:
 	GLFWwindow* GetWindow()
 	{ return m_window; }
 
-	// Return a DPI 'scale' value where 1 ~= 96DPI
-	// Akin to uses of `get_pango_context()->get_resolution() / 96` in glscopeclient
-	float GetContentScale();
+	///@brief Scale factor for UI elements (icons, scrollbars, etc); typically an integer number.
+	float GetUIScale();
+
+	///@brief Scale factor for fonts, applied on top of UI scale factor; often a fractional number.
+	float GetFontScale();
 
 	virtual void Render();
 


### PR DESCRIPTION
This PR includes three parts:

1. Splitting `GetContentScale()` into `GetUIScale()` and `GetFontScale()`
2. Making the two possible to override without recompiling ngscopeclient, on any platform, using `NGSCOPECLIENT_UI_SCALE` and `NGSCOPECLIENT_FONT_SCALE`
3. Auto-detecting these using `GDK_SCALE` and `GDK_DPI_SCALE` on Linux, which should cover both GTK and Qt

This probably breaks scaling, to the extent it did work, on Windows and macOS.