### PR TITLE
8bit/16bit data transfer mode setting for Rigol DHO models.

### DIFF
--- a/src/ngscopeclient/PreferenceSchema.cpp
+++ b/src/ngscopeclient/PreferenceSchema.cpp
@@ -386,6 +386,22 @@ void PreferenceManager::InitializeDefaults()
 					.EnumValue("8 bits", WIDTH_8_BITS)
 					.EnumValue("16 bits", WIDTH_16_BITS)
 				);
+		auto& rigol = drivers.AddCategory("Rigol DHO");
+			rigol.AddPreference(
+				Preference::Enum("data_width", WIDTH_AUTO)
+					.Label("Data Width")
+					.Description(
+					"Data width used when downloading sample data from the instrument.\n\n"
+					"Even if the instrument has a 12-bit ADC, using 8 rather than 16 bit data format allows faster"
+					" waveform update rate.\n\n"
+					"Choose 16 bit mode if you want to privilege data accuracy over refresh rate.\n\n"
+					"Changes to this setting take effect the next time a connection to the instrument is opened; "
+					"the transfer format for active sessions is not updated."
+						)
+					.EnumValue("Auto", WIDTH_AUTO)
+					.EnumValue("8 bits", WIDTH_8_BITS)
+					.EnumValue("16 bits", WIDTH_16_BITS)
+				);
 
 	auto& files = this->m_treeRoot.AddCategory("Files");
 		files.AddPreference(

--- a/src/ngscopeclient/Session.cpp
+++ b/src/ngscopeclient/Session.cpp
@@ -47,6 +47,7 @@
 
 #include "../scopehal/LeCroyOscilloscope.h"
 #include "../scopehal/SiglentSCPIOscilloscope.h"
+#include "../scopehal/RigolOscilloscope.h"
 #include "../scopehal/MockOscilloscope.h"
 #include "../scopeprotocols/EyePattern.h"
 
@@ -2662,6 +2663,19 @@ void Session::ApplyPreferences(shared_ptr<Oscilloscope> scope)
 		else if(dataWidth == WIDTH_16_BITS)
 		{
 			siglent->ForceHDMode(true);
+		}
+	}
+	auto rigol = dynamic_pointer_cast<RigolOscilloscope>(scope);
+	if(rigol)
+	{
+		auto dataWidth = m_preferences.GetEnumRaw("Drivers.Rigol DHO.data_width");
+		if(dataWidth == WIDTH_8_BITS)
+		{
+			rigol->ForceHDMode(false);
+		}
+		else if(dataWidth == WIDTH_16_BITS)
+		{
+			rigol->ForceHDMode(true);
 		}
 	}
 }


### PR DESCRIPTION
As requested by joshua_, here is the 16bit data transfert mode for Rigol DHO models (settings part).
Tested OK on my DHO804. Should work on DHO1000/4000 as well.
I used the same default/8bit/16bit setting system as for Siglent HD models.
Goes with the companion PR on scopehal : https://github.com/ngscopeclient/scopehal/pull/900
