### PR TITLE
Rich UI support for StreamBrowserDialog on oscilloscopes

### DIFF
--- a/src/ngscopeclient/InstrumentThread.cpp
+++ b/src/ngscopeclient/InstrumentThread.cpp
@@ -92,7 +92,7 @@ void InstrumentThread(InstrumentThreadArgs args)
 				{	// Check for trigger state change
 					auto stat = scope->PollTrigger();
 					session->GetInstrumentConnectionState(inst)->m_lastTriggerState = stat;
-					if(stat == Oscilloscope::TRIGGER_MODE_STOP)
+					if(stat == Oscilloscope::TRIGGER_MODE_STOP || stat == Oscilloscope::TRIGGER_MODE_RUN || stat == Oscilloscope::TRIGGER_MODE_TRIGGERED)
 					{	// Final state
 						triggerUpToDate = true;
 					}

--- a/src/ngscopeclient/InstrumentThread.cpp
+++ b/src/ngscopeclient/InstrumentThread.cpp
@@ -93,6 +93,7 @@ void InstrumentThread(InstrumentThreadArgs args)
 			else
 			{
 				auto stat = scope->PollTrigger();
+				session->GetInstrumentConnectionState(inst)->m_lastTriggerState = stat;
 				if(stat == Oscilloscope::TRIGGER_MODE_TRIGGERED)
 					scope->AcquireData();
 			}

--- a/src/ngscopeclient/InstrumentThread.cpp
+++ b/src/ngscopeclient/InstrumentThread.cpp
@@ -65,6 +65,8 @@ void InstrumentThread(InstrumentThreadArgs args)
 	auto bertstate = args.bertstate;
 	auto psustate = args.psustate;
 
+	bool triggerUpToDate = false;
+
 	while(!*args.shuttingDown)
 	{
 		//Flush any pending commands
@@ -86,6 +88,15 @@ void InstrumentThread(InstrumentThreadArgs args)
 			{
 				//LogTrace("Scope isn't armed, sleeping\n");
 				this_thread::sleep_for(chrono::milliseconds(5));
+				if(!triggerUpToDate)
+				{	// Check for trigger state change
+					auto stat = scope->PollTrigger();
+					session->GetInstrumentConnectionState(inst)->m_lastTriggerState = stat;
+					if(stat == Oscilloscope::TRIGGER_MODE_STOP)
+					{	// Final state
+						triggerUpToDate = true;
+					}
+				}
 			}
 
 			//Grab data if it's ready
@@ -96,6 +107,7 @@ void InstrumentThread(InstrumentThreadArgs args)
 				session->GetInstrumentConnectionState(inst)->m_lastTriggerState = stat;
 				if(stat == Oscilloscope::TRIGGER_MODE_TRIGGERED)
 					scope->AcquireData();
+				triggerUpToDate = false;
 			}
 		}
 

--- a/src/ngscopeclient/MainWindow.cpp
+++ b/src/ngscopeclient/MainWindow.cpp
@@ -1277,7 +1277,7 @@ void MainWindow::DockingArea()
 				rightPanelID = topNode->ChildNodes[1]->ID;
 			}
 			else
-				ImGui::DockBuilderSplitNode(topNode->ID, ImGuiDir_Left, 0.1, &leftPanelID, &rightPanelID);
+				ImGui::DockBuilderSplitNode(topNode->ID, ImGuiDir_Left, 0.2, &leftPanelID, &rightPanelID);
 
 			ImGui::DockBuilderDockWindow(m_streamBrowser->GetTitleAndID().c_str(), leftPanelID);
 			ImGui::DockBuilderDockWindow(m_initialWorkspaceDockRequest->GetTitleAndID().c_str(), rightPanelID);

--- a/src/ngscopeclient/Session.h
+++ b/src/ngscopeclient/Session.h
@@ -59,12 +59,6 @@ public:
 		args.shuttingDown = &m_shuttingDown;
 		m_thread = std::make_unique<std::thread>(InstrumentThread, args);
 		m_lastTriggerState = Oscilloscope::TRIGGER_MODE_WAIT;
-		size_t channelNumber = 0;
-	
-		// TODO : temporary => should no longer be needed once GetDownloadProgress() API is available on OscilloscopeChannel
-		if(args.inst)
-			channelNumber = args.inst->GetChannelCount();
-		m_channelDownloadStates.assign(channelNumber,-1);
 	}
 
 	~InstrumentConnectionState()
@@ -81,20 +75,6 @@ public:
 		m_thread = nullptr;
 	}
 
-	int GetChannelDownloadState(size_t i) const
-	{
-		if(i >= m_channelDownloadStates.size())
-			return -1;
-
-		return m_channelDownloadStates[i];
-	}
-
-	void  SetChannelDownloadState(size_t i, int downloadState)
-	{
-		m_channelDownloadStates[i] = downloadState;
-	}
-
-
 	///@brief Termination flag for shutting down the polling thread
 	std::atomic<bool> m_shuttingDown;
 
@@ -103,10 +83,6 @@ public:
 	
 	///@brief Cached trigger state, to reflect in the UI
 	Oscilloscope::TriggerMode m_lastTriggerState;
-
-	// TODO : temporary => should no longer be needed once GetDownloadProgress() API is available on OscilloscopeChannel
-	///@brief Cached download sates, to reflect in the UI
-	std::vector<int> m_channelDownloadStates;
 };
 
 /**

--- a/src/ngscopeclient/Session.h
+++ b/src/ngscopeclient/Session.h
@@ -59,6 +59,12 @@ public:
 		args.shuttingDown = &m_shuttingDown;
 		m_thread = std::make_unique<std::thread>(InstrumentThread, args);
 		m_lastTriggerState = Oscilloscope::TRIGGER_MODE_WAIT;
+		size_t channelNumber = 0;
+	
+		// TODO : temporary => should no longer be needed once GetDownloadProgress() API is available on OscilloscopeChannel
+		if(args.inst)
+			channelNumber = args.inst->GetChannelCount();
+		m_channelDownloadStates.assign(channelNumber,-1);
 	}
 
 	~InstrumentConnectionState()
@@ -75,6 +81,20 @@ public:
 		m_thread = nullptr;
 	}
 
+	int GetChannelDownloadState(size_t i) const
+	{
+		if(i >= m_channelDownloadStates.size())
+			return -1;
+
+		return m_channelDownloadStates[i];
+	}
+
+	void  SetChannelDownloadState(size_t i, int downloadState)
+	{
+		m_channelDownloadStates[i] = downloadState;
+	}
+
+
 	///@brief Termination flag for shutting down the polling thread
 	std::atomic<bool> m_shuttingDown;
 
@@ -83,6 +103,10 @@ public:
 	
 	///@brief Cached trigger state, to reflect in the UI
 	Oscilloscope::TriggerMode m_lastTriggerState;
+
+	// TODO : temporary => should no longer be needed once GetDownloadProgress() API is available on OscilloscopeChannel
+	///@brief Cached download sates, to reflect in the UI
+	std::vector<int> m_channelDownloadStates;
 };
 
 /**

--- a/src/ngscopeclient/Session.h
+++ b/src/ngscopeclient/Session.h
@@ -58,6 +58,7 @@ public:
 		m_shuttingDown = false;
 		args.shuttingDown = &m_shuttingDown;
 		m_thread = std::make_unique<std::thread>(InstrumentThread, args);
+		m_lastTriggerState = Oscilloscope::TRIGGER_MODE_WAIT;
 	}
 
 	~InstrumentConnectionState()
@@ -79,6 +80,9 @@ public:
 
 	///@brief Thread for polling the instrument
 	std::unique_ptr<std::thread> m_thread;
+	
+	///@brief Cached trigger state, to reflect in the UI
+	Oscilloscope::TriggerMode m_lastTriggerState;
 };
 
 /**
@@ -132,6 +136,7 @@ public:
 
 	void AddInstrument(std::shared_ptr<Instrument> inst, bool createDialogs = true);
 	void RemoveInstrument(std::shared_ptr<Instrument> inst);
+	std::shared_ptr<InstrumentConnectionState> GetInstrumentConnectionState(std::shared_ptr<Instrument> inst) { return m_instrumentStates[inst]; }
 
 	bool IsMultiScope()
 	{ return m_multiScope; }

--- a/src/ngscopeclient/StreamBrowserDialog.cpp
+++ b/src/ngscopeclient/StreamBrowserDialog.cpp
@@ -43,7 +43,7 @@ using namespace std;
 // Construction / destruction
 
 StreamBrowserDialog::StreamBrowserDialog(Session& session, MainWindow* parent)
-	: Dialog("Stream Browser", "Stream Browser", ImVec2(300, 400))
+	: Dialog("Stream Browser", "Stream Browser", ImVec2(550, 400))
 	, m_session(session)
 	, m_parent(parent)
 {

--- a/src/ngscopeclient/StreamBrowserDialog.cpp
+++ b/src/ngscopeclient/StreamBrowserDialog.cpp
@@ -120,6 +120,36 @@ bool StreamBrowserDialog::DoRender()
 		if (auto scope = std::dynamic_pointer_cast<Oscilloscope>(inst)) {
 			if (scope->IsOffline()) {
 				renderBadge(ImVec4(0.8, 0.3, 0.3, 1.0) /* XXX: pull color from prefs */, "OFFLINE", "OFFL", NULL);
+			} else {
+				switch (m_session.GetInstrumentConnectionState(inst)->m_lastTriggerState) {
+				case Oscilloscope::TRIGGER_MODE_RUN:
+					/* prefer language "ARMED" to "RUN":
+					 * "RUN" could mean either "waiting
+					 * for trigger" or "currently
+					 * capturing samples post-trigger",
+					 * "ARMED" is unambiguous */
+					renderBadge(ImVec4(0.3, 0.8, 0.3, 1.0), "ARMED", "A", NULL);
+					break;
+				case Oscilloscope::TRIGGER_MODE_STOP:
+					renderBadge(ImVec4(0.8, 0.3, 0.3, 1.0), "STOPPED", "STOP", "S", NULL);
+					break;
+				case Oscilloscope::TRIGGER_MODE_TRIGGERED:
+					renderBadge(ImVec4(0.7, 0.7, 0.3, 1.0), "TRIGGERED", "TRIG'D", "T'D", "T", NULL);
+					break;
+				case Oscilloscope::TRIGGER_MODE_WAIT:
+					/* prefer language "BUSY" to "WAIT":
+					 * "WAIT" could mean "waiting for
+					 * trigger", "BUSY" means "I am
+					 * doing something internally and am
+					 * not ready for some reason" */
+					renderBadge(ImVec4(0.8, 0.3, 0.3, 1.0), "BUSY", "B", NULL);
+					break;
+				case Oscilloscope::TRIGGER_MODE_AUTO:
+					renderBadge(ImVec4(0.3, 0.8, 0.3, 1.0), "AUTO", "A", NULL);
+					break;
+				default:
+					break;
+				}
 			}
 		}
 		

--- a/src/ngscopeclient/StreamBrowserDialog.cpp
+++ b/src/ngscopeclient/StreamBrowserDialog.cpp
@@ -108,7 +108,7 @@ bool StreamBrowserDialog::DoRender()
 			break;
 		}
 	};
-	auto renderDownloadProgress = [&badgeXMin, &badgeXCur](OscilloscopeChannel *scopechan)
+	auto renderDownloadProgress = [&badgeXMin, &badgeXCur](InstrumentChannel *chan)
 	{
 		static const char* const download[] = {"DOWNLOADING", "DOWNLOAD" ,"DL","D", NULL};
 		
@@ -131,7 +131,7 @@ bool StreamBrowserDialog::DoRender()
 		static const char* const* labels;
 		ImVec4 color;
 		bool hasProgress = false;
-		switch(scopechan->GetDownloadState())
+		switch(chan->GetDownloadState())
 		{
 			case InstrumentChannel::DownloadState::DOWNLOAD_NONE:
 			case InstrumentChannel::DownloadState::DOWNLOAD_UNKNOWN:
@@ -188,7 +188,7 @@ bool StreamBrowserDialog::DoRender()
 				if(hasProgress)
 				{
 					ImGui::SameLine();
-					ImGui::ProgressBar(scopechan->GetDownloadProgress(), ImVec2(PROGRESS_BAR_WIDTH, ImGui::GetFontSize()));
+					ImGui::ProgressBar(chan->GetDownloadProgress(), ImVec2(PROGRESS_BAR_WIDTH, ImGui::GetFontSize()));
 				}
 
 				return;
@@ -322,16 +322,11 @@ bool StreamBrowserDialog::DoRender()
 				
 				// Channel decoration
 				startBadgeLine();
-				if (scopechan) 
+				if (scopechan && !scopechan->IsEnabled())
 				{
-					if (!scopechan->IsEnabled()) 
-					{
-						renderBadge(ImVec4(0.4, 0.4, 0.4, 1.0) /* XXX: pull color from prefs */, "disabled", "disa", NULL);
-					}
-					else
-					{
-						renderDownloadProgress(scopechan);
-					}
+					renderBadge(ImVec4(0.4, 0.4, 0.4, 1.0) /* XXX: pull color from prefs */, "disabled", "disa", NULL);
+				} else {
+					renderDownloadProgress(chan);
 				}
 
 				if(open)

--- a/src/ngscopeclient/StreamBrowserDialog.cpp
+++ b/src/ngscopeclient/StreamBrowserDialog.cpp
@@ -263,7 +263,6 @@ bool StreamBrowserDialog::DoRender()
 				}
 
 				bool hasChildren = !singleStream || renderScopeProps;
-				bool triggerArmed = scope ? scope->IsTriggerArmed() : false;
 
 				if (chan->m_displaycolor != "") {
 					ImGui::PushStyleColor(ImGuiCol_Text, ColorFromString(chan->m_displaycolor));
@@ -303,69 +302,17 @@ bool StreamBrowserDialog::DoRender()
 				// Channel decoration
 				startBadgeLine();
 				auto scopechan = dynamic_cast<OscilloscopeChannel *>(chan);
-				if (scopechan) {
-					if (!scopechan->IsEnabled()) {
+				if (scopechan) 
+				{
+					if (!scopechan->IsEnabled()) 
+					{
 						renderBadge(ImVec4(0.4, 0.4, 0.4, 1.0) /* XXX: pull color from prefs */, "disabled", "disa", NULL);
 					}
-					else if(scope) {
-						int progress = DownloadState::DOWNLOAD_NONE;
-						// TODO get this out of GetDownloadState() channel API when implemented
-						// For now, we simulate it for demonstration purpose
-						uint64_t sampleDepth = scope->GetSampleDepth();
-						if(sampleDepth <= 100000)
-						{
-							progress = DownloadState::DOWNLOAD_PROGRESS_DISABLED;
-						}
+					else
+					{
+						int progress = scopechan->GetDownloadState();
 						if(progress != DownloadState::DOWNLOAD_PROGRESS_DISABLED)
 						{
-							if(state)
-							{
-								progress = state->GetChannelDownloadState(i);
-								if(triggerArmed)
-								{
-									// Render method is called 60 times per second
-									// We want to simulate a download time of 1 MSample/S
-									uint64_t downloadIncrement = std::max(((1000000ULL*100/sampleDepth)/60),1ULL);
-									if(i == 0)
-									{	// Start with first channel
-										if(progress<=DownloadState::DOWNLOAD_STARTED)
-										{	// Restart all channels
-											for(size_t j = 0 ; j < channelCount ; j++)
-											{
-												state->SetChannelDownloadState(j,DownloadState::DOWNLOAD_WAITING);
-											}
-										}
-										if(progress<DownloadState::DOWNLOAD_FINISHED)
-										{
-											progress+=downloadIncrement;
-										}
-									}
-									else if(state->GetChannelDownloadState(i-1)>=DOWNLOAD_FINISHED)
-									{
-										if(progress<DownloadState::DOWNLOAD_FINISHED)
-										{
-											progress+=downloadIncrement;
-										}
-									}
-									if(i == (channelCount-1) && progress>=DownloadState::DOWNLOAD_FINISHED)
-									{	// Start over
-										for(size_t j = 0 ; j < channelCount ; j++)
-										{
-											state->SetChannelDownloadState(j,DownloadState::DOWNLOAD_WAITING);
-										}
-									}
-									else
-									{
-										if(progress>DownloadState::DOWNLOAD_FINISHED)
-											progress = DownloadState::DOWNLOAD_FINISHED;
-										state->SetChannelDownloadState(i,progress);
-									}
-								}
-								else if(progress != DownloadState::DOWNLOAD_NONE)
-								{	// Set download state to non
-									state->SetChannelDownloadState(i,DownloadState::DOWNLOAD_NONE);
-								}
-							}
 							renderDownloadProgress(progress);
 						}
 					}

--- a/src/ngscopeclient/StreamBrowserDialog.cpp
+++ b/src/ngscopeclient/StreamBrowserDialog.cpp
@@ -65,6 +65,18 @@ StreamBrowserDialog::~StreamBrowserDialog()
  */
 bool StreamBrowserDialog::DoRender()
 {
+	// Some helpers for rendering widgets that appear in the StreamBrowserDialog.
+	
+	// Render a link of the "Sample rate: 4 GSa/s" type that shows up in the
+	// scope properties box.
+	auto renderInfoLink = [](const char *label, const char *linktext, bool &clicked, bool &hovered)
+	{
+		ImGui::Text("%s: ", label);
+		ImGui::SameLine(0, 0);
+		clicked |= ImGui::TextLink(linktext);
+		hovered |= ImGui::IsItemHovered();
+	};
+	
 	//Add all instruments
 	auto insts = m_session.GetInstruments();
 	for(auto inst : insts)
@@ -86,15 +98,15 @@ bool StreamBrowserDialog::DoRender()
 		if(instIsOpen)
 		{
 			if (auto scope = std::dynamic_pointer_cast<Oscilloscope>(inst)) {
-				ImGui::BeginChild("sample_params", ImVec2(0, 50), ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Border);
+				ImGui::BeginChild("sample_params", ImVec2(0, 0), ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Border);
 				
 				auto srate_txt = Unit(Unit::UNIT_SAMPLERATE).PrettyPrint(scope->GetSampleRate());
 				auto sdepth_txt = Unit(Unit::UNIT_SAMPLEDEPTH).PrettyPrint(scope->GetSampleDepth());
 				
 				bool clicked = false;
 				bool hovered = false;
-				ImGui::Text("Sample rate: "); ImGui::SameLine(0, 0); clicked |= ImGui::TextLink(srate_txt.c_str()); hovered |= ImGui::IsItemHovered();
-				ImGui::Text("Sample depth: "); ImGui::SameLine(0, 0); clicked |= ImGui::TextLink(sdepth_txt.c_str()); hovered |= ImGui::IsItemHovered();
+				renderInfoLink("Sample rate", srate_txt.c_str(), clicked, hovered);
+				renderInfoLink("Sample depth", sdepth_txt.c_str(), clicked, hovered);
 				if (clicked) {
 					m_parent->ShowTimebaseProperties();
 				}

--- a/src/ngscopeclient/StreamBrowserDialog.cpp
+++ b/src/ngscopeclient/StreamBrowserDialog.cpp
@@ -100,7 +100,7 @@ bool StreamBrowserDialog::DoRender()
 			}
 			
 			// ok, we have enough space -- commit to it!
-			badgeXCur -= xsz;
+			badgeXCur -= xsz - ImGui::GetStyle().ItemSpacing.x;
 			ImGui::SameLine(badgeXCur);
 			ImGui::PushStyleColor(ImGuiCol_Button, color);
 			ImGui::SmallButton(label);

--- a/src/ngscopeclient/StreamBrowserDialog.cpp
+++ b/src/ngscopeclient/StreamBrowserDialog.cpp
@@ -348,8 +348,7 @@ bool StreamBrowserDialog::DoRender()
 				
 							if(isDigital)
 							{
-								// TODO: Digital Threshold value is not cached on most scopes... uncomment the code bellow ONLY once it has been cached on all drivers
-								auto threshold_txt = Unit(Unit::UNIT_VOLTS).PrettyPrint(0/*scope->GetDigitalThreshold(i)*/);
+								auto threshold_txt = Unit(Unit::UNIT_VOLTS).PrettyPrint(scope->GetDigitalThreshold(i));
 					
 								bool clicked = false;
 								bool hovered = false;

--- a/src/ngscopeclient/StreamBrowserDialog.cpp
+++ b/src/ngscopeclient/StreamBrowserDialog.cpp
@@ -359,7 +359,7 @@ bool StreamBrowserDialog::DoRender()
 				{
 					renderBadge(ImVec4(0.4, 0.4, 0.4, 1.0) /* XXX: pull color from prefs */, "disabled", "disa", NULL);
 				} 
-				else if (state && state->m_lastTriggerState != Oscilloscope::TRIGGER_MODE_STOP) 
+				else if (state) 
 				{
 					renderDownloadProgress(inst, chan);
 				}

--- a/src/ngscopeclient/StreamBrowserDialog.h
+++ b/src/ngscopeclient/StreamBrowserDialog.h
@@ -56,7 +56,7 @@ protected:
 	Session& m_session;
 	MainWindow* m_parent;
 
-	std::map<std::pair<std::shared_ptr<Instrument>, InstrumentChannel *>, bool> m_channelDownloadIsSlow;
+	std::map<std::shared_ptr<Instrument>, bool> m_instrumentDownloadIsSlow;
 };
 
 #endif

--- a/src/ngscopeclient/StreamBrowserDialog.h
+++ b/src/ngscopeclient/StreamBrowserDialog.h
@@ -35,6 +35,8 @@
 #ifndef StreamBrowserDialog_h
 #define StreamBrowserDialog_h
 
+#include <map>
+
 #include "Dialog.h"
 #include "Session.h"
 
@@ -53,6 +55,8 @@ protected:
 
 	Session& m_session;
 	MainWindow* m_parent;
+
+	std::map<std::pair<std::shared_ptr<Instrument>, InstrumentChannel *>, bool> m_channelDownloadIsSlow;
 };
 
 #endif


### PR DESCRIPTION
This is a draft PR to experiment with some UI for #760 and #761, and in general, the concept of making the StreamBrowserDialog meaningfully richer in showing instrument and system status.  Here is what I have right now:

<img width="1066" alt="image" src="https://github.com/user-attachments/assets/a7fa92df-4982-4696-a909-1e1edfe38218">

Obviously there is going to be a lot of stuff to add and cleanup to do before this is ready to merge, and probably will include some scopehal changes, but this is the current UI metaphor set that I'm playing with.  Title bars are still draggable, for instance, but other parts are not, and I think this makes some sense.  Some things to consider at some point:

- [x] Do something sensible if the Stream Browser is not wide enough to contain a badge
- [x] Show channel properties
- [ ] Maybe make better use of wide horizontal Stream Browsers to provide more information in fewer lines (i.e., channel coupling?)
- [ ] Trigger settings seem like they are part of an oscilloscope?
- [ ] At that point, is it really even called a Stream Browser if copying Streams around is just a small part of its functionality?
- [ ] Should there be a UI affordance of 'things that you can drag' to indicate 'try dragging me to a filter graph'?  (Think, for instance, Apple's Interface Builder has the little blue bullseye for 'draggable and droppable things'.)