### PR TITLE
Windows uart support

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -44,6 +44,7 @@ jobs:
           yaml-cpp:p
           glfw:p
           catch:p
+          libserialport:p
           vulkan-headers:p
           vulkan-loader:p
           shaderc:p


### PR DESCRIPTION
This is a part of a group of 3 PRs to add support for uart transport on Windows through libserialport.
Here is the CI update part.