### PR TITLE
Specan fixes

### DIFF
--- a/src/ngscopeclient/TimebasePropertiesDialog.cpp
+++ b/src/ngscopeclient/TimebasePropertiesDialog.cpp
@@ -82,6 +82,10 @@ TimebasePropertiesPage::TimebasePropertiesPage(shared_ptr<Oscilloscope> scope)
 	}
 
 	Unit hz(Unit::UNIT_HZ);
+
+	m_rbw = scope->GetResolutionBandwidth();
+	m_rbwText = hz.PrettyPrint(m_rbw);
+
 	m_span = scope->GetSpan();
 	m_spanText = hz.PrettyPrint(m_span);
 
@@ -237,9 +241,21 @@ bool TimebasePropertiesDialog::DoRender()
 					HelpMarker("Number of points in the sweep");
 				}
 
+				Unit hz(Unit::UNIT_HZ);
+
+				// Resolution Bandwidh
+				ImGui::SetNextItemWidth(width);
+				if(UnitInputWithImplicitApply("Rbw", p->m_rbwText, p->m_rbw, hz))
+				{
+					scope->SetResolutionBandwidth(p->m_rbw);
+					// Update with values from the device
+					p->m_rbw = scope->GetResolutionBandwidth();
+					p->m_rbwText = hz.PrettyPrint(p->m_rbw);
+				}
+				HelpMarker("Resolution Bandwidth");
+
 				//Frequency
 				bool changed = false;
-				Unit hz(Unit::UNIT_HZ);
 
 				ImGui::SetNextItemWidth(width);
 				if(UnitInputWithImplicitApply("Start", p->m_startText, p->m_start, hz))

--- a/src/ngscopeclient/TimebasePropertiesDialog.h
+++ b/src/ngscopeclient/TimebasePropertiesDialog.h
@@ -58,6 +58,10 @@ public:
 	//(only valid if both RT and equivalent are available)
 	int m_samplingMode;
 
+	//Resolution Bandwidth
+	std::string m_rbwText;
+	int64_t m_rbw;
+
 	//Frequency domain controls
 	std::string m_centerText;
 	double m_center;


### PR DESCRIPTION
Hi Andrew,

Here is the PR for specans:
- Adds rbw value to TimebasePropertiesDialog
- Adapts instrument properties in StreamBrowserDialog according to HasTimebaseControls() and HasFrequencyControls() values
- Adds missing PushIds that could lead to collisions when text/values were the same on two links.
![image](https://github.com/user-attachments/assets/c96049d1-057c-47fd-9b01-2c18bc42bafa)

A call to GetResolutionBandwidth() and GetCenterFrequency() is made in the render method of StreamBrowserDialog.
A PR will come on scopehal to make these methods cache the value for Tek driver (which is the only one that does not cache the value).

Best,

Frederic.