### PR TITLE
Stream browser filter rendering

### DIFF
--- a/src/ngscopeclient/StreamBrowserDialog.h
+++ b/src/ngscopeclient/StreamBrowserDialog.h
@@ -87,7 +87,10 @@ protected:
 	void renderChannelNode(shared_ptr<Instrument> instrument, size_t channelIndex, bool isLast);
 
 	// Rendering of a stream node
-	void renderStreamNode(shared_ptr<Instrument> instrument, InstrumentChannel* channel, size_t streamIndex, bool renderName, bool renderProps);
+	void renderStreamNode(shared_ptr<Instrument> instrument, InstrumentChannel* channel, size_t streamIndex, bool renderName, bool renderProps, bool isLast);
+
+	// Rendering of an Filter node
+	void renderFilterNode(Filter* filter);
 
 	Session& m_session;
 	MainWindow* m_parent;


### PR DESCRIPTION
Hi Andrew,

This one is for Filter rendering in StreamBrowserDialog:
![image](https://github.com/user-attachments/assets/5f6e7d08-518b-4403-a5a1-50c2d182aaee)

Not much to say about it, I reused/adapted the the renderStreamNode() method for that purpose + created a renderFilterNode() method.
For now properties are shown only for ANALOG and DIGITAL streams. For other streams, one generic "Properties" link is added after the last stream of the channel/filter to open the relevant Properties dialog.

Best,

Frederic.