### PR TITLE
CI Build for Windows MSI installer

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -62,7 +62,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake .. -DWIXPATH="C:\Program Files (x86)\WiX Toolset v3.14\bin" -GNinja
+        cmake .. --trace -DWIXPATH="C:\Program Files (x86)\WiX Toolset v3.14\bin" -GNinja
         ninja
 
     - name: Test

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -54,6 +54,7 @@ jobs:
 
     - name: Install WiX
       run: |
+        choco install wixtoolset
         where wix
         wix --version
       shell: cmd

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -60,6 +60,7 @@ jobs:
         dotnet tool install --global wix
         wix --version
         where wix
+      shell: cmd
 
     - name: Build
       run: |

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -54,7 +54,7 @@ jobs:
 
 #    - name: Add msbuild to PATH
 #      uses: microsoft/setup-msbuild@v1.1
-    
+#    
     - name: Install WiX
       run: |
 #        dotnet tool install --global wix

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -52,6 +52,15 @@ jobs:
           ffts:p
           hidapi:p
 
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1.1
+    
+    - name: Install WiX
+      run: |
+        dotnet tool install --global wix
+        wix --version
+        where wix
+
     - name: Build
       run: |
         mkdir build

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -53,9 +53,9 @@ jobs:
           hidapi:p
 
     - name: Install WiX
+      if: ${{ matrix.sys == 'ucrt64' }}
       run: |
         choco install wixtoolset --force
-        # "C:\Program Files (x86)\WiX Toolset v3.14\bin\candle.exe" -?
       shell: cmd
 
     - name: Build And Dist

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -19,9 +19,9 @@ jobs:
     strategy:
       matrix:
         include:
-          # - { sys: mingw64, env: x86_64 }
+          - { sys: mingw64, env: x86_64 }
           - { sys: ucrt64,  env: ucrt-x86_64 }
-          # - { sys: clang64, env: clang-x86_64 }
+          - { sys: clang64, env: clang-x86_64 }
 
     steps:
     - uses: actions/checkout@v4
@@ -55,14 +55,23 @@ jobs:
     - name: Install WiX
       run: |
         choco install wixtoolset --force
-        "C:\Program Files (x86)\WiX Toolset v3.14\bin\candle.exe" -?
+        # "C:\Program Files (x86)\WiX Toolset v3.14\bin\candle.exe" -?
       shell: cmd
 
-    - name: Build
+    - name: Build And Dist
+      if: ${{ matrix.sys == 'ucrt64' }}
       run: |
         mkdir build
         cd build
         cmake .. -DWIXPATH="C:\Program Files (x86)\WiX Toolset v3.14\bin" -GNinja
+        ninja
+
+    - name: Build Only
+      if: ${{ matrix.sys != 'ucrt64' }}
+      run: |
+        mkdir build
+        cd build
+        cmake .. -GNinja
         ninja
 
     - name: Test
@@ -84,12 +93,14 @@ jobs:
     #     path: msys2/*.zst
 
     - name: Upload Artifacts (ngscopeclient portable zip)
+      if: ${{ matrix.sys == 'ucrt64' }}
       uses: actions/upload-artifact@v4
       with:
         name: ngscopeclient-windows-portable-${{ runner.os }}-${{ github.job }}
         path: build/dist/ngscopeclient*.zip
 
     - name: Upload Artifacts (ngscopeclient MSI)
+      if: ${{ matrix.sys == 'ucrt64' }}
       uses: actions/upload-artifact@v4
       with:
         name: ngscopeclient-${{ runner.os }}-${{ github.job }}.msi

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Install WiX
       run: |
-        choco install wixtoolset
+        choco install wixtoolset --force
         "C:\Program Files (x86)\WiX Toolset v3.14\bin\candle.exe" -?
       shell: cmd
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -52,12 +52,8 @@ jobs:
           ffts:p
           hidapi:p
 
-#    - name: Add msbuild to PATH
-#      uses: microsoft/setup-msbuild@v1.1
-#    
     - name: Install WiX
       run: |
-#        dotnet tool install --global wix
         where wix
         wix --version
       shell: cmd

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -19,9 +19,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - { sys: mingw64, env: x86_64 }
+          # - { sys: mingw64, env: x86_64 }
           - { sys: ucrt64,  env: ucrt-x86_64 }
-          - { sys: clang64, env: clang-x86_64 }
+          # - { sys: clang64, env: clang-x86_64 }
 
     steps:
     - uses: actions/checkout@v4
@@ -62,7 +62,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake .. --trace -DWIXPATH="C:\Program Files (x86)\WiX Toolset v3.14\bin" -GNinja
+        cmake .. -DWIXPATH="C:\Program Files (x86)\WiX Toolset v3.14\bin" -GNinja
         ninja
 
     - name: Test

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -55,8 +55,8 @@ jobs:
     - name: Install WiX
       run: |
         choco install wixtoolset
-        where wix
-        wix --version
+        dir "C:\Program Files (x86)\WiX Toolset v3.14\bin"
+        "C:\Program Files (x86)\WiX Toolset v3.14\bin\candle.exe" -?
       shell: cmd
 
     - name: Build

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -52,14 +52,14 @@ jobs:
           ffts:p
           hidapi:p
 
-    - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.1
+#    - name: Add msbuild to PATH
+#      uses: microsoft/setup-msbuild@v1.1
     
     - name: Install WiX
       run: |
-        dotnet tool install --global wix
-        wix --version
+#        dotnet tool install --global wix
         where wix
+        wix --version
       shell: cmd
 
     - name: Build

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -55,7 +55,6 @@ jobs:
     - name: Install WiX
       run: |
         choco install wixtoolset
-        dir "C:\Program Files (x86)\WiX Toolset v3.14\bin"
         "C:\Program Files (x86)\WiX Toolset v3.14\bin\candle.exe" -?
       shell: cmd
 
@@ -63,7 +62,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake .. -GNinja
+        cmake .. -DWIXPATH="C:\Program Files (x86)\WiX Toolset v3.14\bin" -GNinja
         ninja
 
     - name: Test

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -83,14 +83,14 @@ jobs:
     #     name: glscopeclient-windows-${{ runner.os }}-${{ github.job }}
     #     path: msys2/*.zst
 
-    # - name: Upload Artifacts (ngscopeclient portable zip)
-    #   uses: actions/upload-artifact@v4
-    #   with:
-    #     name: ngscopeclient-windows-portable-${{ runner.os }}-${{ github.job }}
-    #     path: build/dist/ngscopeclient*.zip
+    - name: Upload Artifacts (ngscopeclient portable zip)
+      uses: actions/upload-artifact@v4
+      with:
+        name: ngscopeclient-windows-portable-${{ runner.os }}-${{ github.job }}
+        path: build/dist/ngscopeclient*.zip
 
-    # - name: Upload Artifacts (ngscopeclient MSI)
-    #   uses: actions/upload-artifact@v4
-    #   with:
-    #     name: ngscopeclient-${{ runner.os }}-${{ github.job }}.msi
-    #     path: build/dist/ngscopeclient*.msi
+    - name: Upload Artifacts (ngscopeclient MSI)
+      uses: actions/upload-artifact@v4
+      with:
+        name: ngscopeclient-${{ runner.os }}-${{ github.job }}.msi
+        path: build/dist/ngscopeclient*.msi

--- a/src/ngscopeclient/CMakeLists.txt
+++ b/src/ngscopeclient/CMakeLists.txt
@@ -245,7 +245,7 @@ if(WIXPATH AND WIN32)
 				${CMAKE_BINARY_DIR}/lib/scopeprotocols/libscopeprotocols.dll
 				${CMAKE_BINARY_DIR}/src/ngscopeclient/ngscopeclient.exe
 				${CMAKE_BINARY_DIR}/dist/ngscopeclient_windows_x64
-		COMMAND bash -c \"cp -R /mingw64/share/licenses ${CMAKE_BINARY_DIR}/dist/ngscopeclient_windows_x64\"
+		# COMMAND bash -c \"cp -R /mingw64/share/licenses ${CMAKE_BINARY_DIR}/dist/ngscopeclient_windows_x64\"
 		COMMAND bash -c \"wget https://github.com/bvernoux/mingw-bundledlls/releases/download/v0.2.4/mingw-bundledlls-0.2.4-1-x86_64.pkg.tar.zst && pacman -U --noconfirm mingw-bundledlls-*.pkg.tar.zst && rm -f mingw-bundledlls-*.pkg.tar.zst\"
 		COMMAND bash -c \"export MINGW_BUNDLEDLLS_SEARCH_PATH='${MINGW64_BIN_PATH}\;../../lib/log\;../../lib/scopeexports\;../../lib/scopehal\;../../lib/scopeprotocols\;../../lib/xptools' && mingw-bundledlls ${CMAKE_BINARY_DIR}/dist/ngscopeclient_windows_x64/ngscopeclient.exe --copy\")
 

--- a/src/ngscopeclient/CMakeLists.txt
+++ b/src/ngscopeclient/CMakeLists.txt
@@ -245,7 +245,7 @@ if(WIXPATH AND WIN32)
 				${CMAKE_BINARY_DIR}/lib/scopeprotocols/libscopeprotocols.dll
 				${CMAKE_BINARY_DIR}/src/ngscopeclient/ngscopeclient.exe
 				${CMAKE_BINARY_DIR}/dist/ngscopeclient_windows_x64
-		COMMAND bash -c \"cp -R ${MINGW64_BIN_PATH}/../../mingw64/share/licenses ${CMAKE_BINARY_DIR}/dist/ngscopeclient_windows_x64\"
+		COMMAND bash -c \"cp -R ${MINGW64_BIN_PATH}/../share/licenses ${CMAKE_BINARY_DIR}/dist/ngscopeclient_windows_x64\"
 		COMMAND bash -c \"wget https://github.com/bvernoux/mingw-bundledlls/releases/download/v0.2.4/mingw-bundledlls-0.2.4-1-x86_64.pkg.tar.zst && pacman -U --noconfirm mingw-bundledlls-*.pkg.tar.zst && rm -f mingw-bundledlls-*.pkg.tar.zst\"
 		COMMAND bash -c \"export MINGW_BUNDLEDLLS_SEARCH_PATH='${MINGW64_BIN_PATH}\;../../lib/log\;../../lib/scopeexports\;../../lib/scopehal\;../../lib/scopeprotocols\;../../lib/xptools' && mingw-bundledlls ${CMAKE_BINARY_DIR}/dist/ngscopeclient_windows_x64/ngscopeclient.exe --copy\")
 

--- a/src/ngscopeclient/CMakeLists.txt
+++ b/src/ngscopeclient/CMakeLists.txt
@@ -245,7 +245,7 @@ if(WIXPATH AND WIN32)
 				${CMAKE_BINARY_DIR}/lib/scopeprotocols/libscopeprotocols.dll
 				${CMAKE_BINARY_DIR}/src/ngscopeclient/ngscopeclient.exe
 				${CMAKE_BINARY_DIR}/dist/ngscopeclient_windows_x64
-		# COMMAND bash -c \"cp -R /mingw64/share/licenses ${CMAKE_BINARY_DIR}/dist/ngscopeclient_windows_x64\"
+		COMMAND bash -c \"cp -R ${MINGW64_BIN_PATH}/../../mingw64/share/licenses ${CMAKE_BINARY_DIR}/dist/ngscopeclient_windows_x64\"
 		COMMAND bash -c \"wget https://github.com/bvernoux/mingw-bundledlls/releases/download/v0.2.4/mingw-bundledlls-0.2.4-1-x86_64.pkg.tar.zst && pacman -U --noconfirm mingw-bundledlls-*.pkg.tar.zst && rm -f mingw-bundledlls-*.pkg.tar.zst\"
 		COMMAND bash -c \"export MINGW_BUNDLEDLLS_SEARCH_PATH='${MINGW64_BIN_PATH}\;../../lib/log\;../../lib/scopeexports\;../../lib/scopehal\;../../lib/scopeprotocols\;../../lib/xptools' && mingw-bundledlls ${CMAKE_BINARY_DIR}/dist/ngscopeclient_windows_x64/ngscopeclient.exe --copy\")
 


### PR DESCRIPTION
Hi Andrew,

Here is the PR to add support for CI build of MSI installer on Windows.
Installer is built against ucrt64 environment (since gcc is required for WiX toolset to work and clang64 does not provide gcc).
As discussed msys64 and clang64 built are still active but without the CPack part.
MSI installer and protable zip artifacts are uploaded at the end of the build.

Best,

Frederic.