### PR TITLE
Fix high DPI scaling on macOS

### DIFF
--- a/src/ngscopeclient/VulkanWindow.cpp
+++ b/src/ngscopeclient/VulkanWindow.cpp
@@ -189,9 +189,8 @@ VulkanWindow::VulkanWindow(const string& title, shared_ptr<QueueHandle> queue)
 
 	//WORKAROUND: handle HiDPI correctly on macOS.
 	//This is probably wrong, per comment in imgui_impl_glfw "Apple platforms use FramebufferScale"
-#ifdef __APPLE__
-	io.FontGlobalScale = 1.0f / scale;
-#else
+	//On macOS, setting FontScaleMain appears to double the scaling
+#ifndef __APPLE__
 	ImGui::GetStyle().FontScaleMain = scale;
 #endif
 


### PR DESCRIPTION
The display scaling of ngscopeclient on macOS appears to have changed at some point. I found that removing the special case for macOS resulted in correct UI scaling.

I tested multiple OS display scales, and this seems to work much better. Before it was about 1/2 the scale it should be. I'm not sure if this works on other macOS versions though. If you have a Mac, please help test it out!

**Before:**
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/4167d294-22ea-4d76-bb6f-108b8bccb186" />

**After:**
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/fbf9774c-a696-4ec6-b89f-96253e362a0b" />