### PR TITLE
Migrate to FFTW from FFTS inside unit tests

### DIFF
--- a/.github/workflows/CodeQL.yml
+++ b/.github/workflows/CodeQL.yml
@@ -59,7 +59,8 @@ jobs:
           catch2 \
           mesa-vulkan-drivers \
           libhidapi-dev \
-          ccache
+          ccache \
+          libfftw3-dev
 
     - name: Load Vulkan SDK Repo (Ubuntu 22.04)
       run: |
@@ -67,30 +68,6 @@ jobs:
         sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-${{ env.SDK_VERSION_REPO }}-jammy.list https://packages.lunarg.com/vulkan/${{ env.SDK_VERSION_REPO }}/lunarg-vulkan-${{ env.SDK_VERSION_REPO }}-jammy.list
         sudo apt update
         sudo apt install vulkan-sdk
-
-    - name: Cache FFTS
-      uses: actions/cache@v4
-      with:
-        path: ~/ffts
-        key: ${{ runner.os }}-ubuntu-22.04-ffts
-
-    - name: Clone and Build FFTS Library
-      run: |
-        if [[ ! -d ~/ffts ]]; then
-          cd
-          git clone https://github.com/anthonix/ffts.git
-          cd ffts
-          mkdir build
-          cd build
-          cmake \
-            -DENABLE_SHARED=ON \
-            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
-            -GNinja \
-            ..
-          ninja
-        fi
-        cd ~/ffts/build
-        sudo ninja install
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/build-arch.yml
+++ b/.github/workflows/build-arch.yml
@@ -55,7 +55,8 @@ jobs:
           ccache \
           ninja \
           vulkan-swrast \
-          lsb-release
+          lsb-release \
+          fftw
 
     - name: Install Docs Dependencies
       if: ${{ matrix.docs }}
@@ -109,33 +110,6 @@ jobs:
         cd VulkanSDK
         curl -LO https://sdk.lunarg.com/sdk/download/${{ env.SDK_VERSION_STANDALONE }}/linux/vulkansdk-linux-x86_64-${{ env.SDK_VERSION_STANDALONE }}.tar.xz
         tar xf vulkansdk-linux-x86_64-${{ env.SDK_VERSION_STANDALONE }}.tar.xz
-
-    - name: Cache FFTS
-      uses: actions/cache@v4
-      with:
-        path: ~/ffts
-        key: ${{ runner.os }}-${{ matrix.os.container }}-ffts
-
-    - name: Clone and Build FFTS Library
-      run: |
-        [[  ${{ matrix.docs }} = 'false' ]] && export CMAKE_C_COMPILER_LAUNCHER=ccache && export CMAKE_CXX_COMPILER_LAUNCHER=ccache
-        if [[ ! -d ~/ffts ]]; then
-          export CC=/usr/bin/gcc-14
-          export CXX=/usr/bin/g++-14
-          cd
-          git clone https://github.com/anthonix/ffts.git
-          cd ffts
-          mkdir build
-          cd build
-          cmake \
-            -DENABLE_SHARED=ON \
-            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
-            -GNinja \
-            ..
-          ninja
-        fi
-        cd ~/ffts/build
-        ninja install
 
     - name: Configure
       run: |

--- a/.github/workflows/build-debian.yml
+++ b/.github/workflows/build-debian.yml
@@ -67,7 +67,8 @@ jobs:
           glslang-tools \
           spirv-tools \
           glslc \
-          lsb-release
+          lsb-release \
+          libfftw3-dev
 
     - name: Install Docs Dependencies
       if: ${{ matrix.docs }}
@@ -112,31 +113,6 @@ jobs:
         cd VulkanSDK
         curl -LO https://sdk.lunarg.com/sdk/download/${{ env.SDK_VERSION_STANDALONE }}/linux/vulkansdk-linux-x86_64-${{ env.SDK_VERSION_STANDALONE }}.tar.xz
         tar xf vulkansdk-linux-x86_64-${{ env.SDK_VERSION_STANDALONE }}.tar.xz
-
-    - name: Cache FFTS
-      uses: actions/cache@v4
-      with:
-        path: ~/ffts
-        key: ${{ runner.os }}-${{ matrix.os.container }}-ffts
-
-    - name: Clone and Build FFTS Library
-      run: |
-        [[  ${{ matrix.docs }} = 'false' ]] && export CMAKE_C_COMPILER_LAUNCHER=ccache && export CMAKE_CXX_COMPILER_LAUNCHER=ccache
-        if [[ ! -d ~/ffts ]]; then
-          cd
-          git clone https://github.com/anthonix/ffts.git
-          cd ffts
-          mkdir build
-          cd build
-          cmake \
-            -DENABLE_SHARED=ON \
-            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
-            -GNinja \
-            ..
-          ninja
-        fi
-        cd ~/ffts/build
-        ninja install
 
     - name: Configure
       run: |

--- a/.github/workflows/build-fedora.yml
+++ b/.github/workflows/build-fedora.yml
@@ -54,7 +54,8 @@ jobs:
           fedora-packager \
           rpmdevtools \
           mesa-vulkan-drivers \
-          lsb-release
+          lsb-release \
+          fftw3-devel
 
     - name: Install Docs Dependencies
       if: ${{ matrix.docs }}
@@ -110,31 +111,6 @@ jobs:
         cd VulkanSDK
         curl -LO https://sdk.lunarg.com/sdk/download/${{ env.SDK_VERSION_STANDALONE }}/linux/vulkansdk-linux-x86_64-${{ env.SDK_VERSION_STANDALONE }}.tar.xz
         tar xf vulkansdk-linux-x86_64-${{ env.SDK_VERSION_STANDALONE }}.tar.xz
-
-    - name: Cache FFTS
-      uses: actions/cache@v4
-      with:
-        path: ~/ffts
-        key: ${{ runner.os }}-${{ matrix.os.container }}-ffts
-
-    - name: Clone and Build FFTS Library
-      run: |
-        [[  ${{ matrix.docs }} = 'false' ]] && export CMAKE_C_COMPILER_LAUNCHER=ccache && export CMAKE_CXX_COMPILER_LAUNCHER=ccache
-        if [[ ! -d ~/ffts ]]; then
-          cd
-          git clone https://github.com/anthonix/ffts.git
-          cd ffts
-          mkdir build
-          cd build
-          cmake \
-            -DENABLE_SHARED=ON \
-            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
-            -GNinja \
-            ..
-          ninja
-        fi
-        cd ~/ffts/build
-        sudo ninja install
 
     - name: Configure
       run: |

--- a/.github/workflows/build-macos-arm.yml
+++ b/.github/workflows/build-macos-arm.yml
@@ -43,7 +43,8 @@ jobs:
           shaderc \
           molten-vk \
           ninja \
-          hidapi
+          hidapi \
+          fftw
 
     - name: Configure
       run: |

--- a/.github/workflows/build-macos-intel.yml
+++ b/.github/workflows/build-macos-intel.yml
@@ -43,33 +43,8 @@ jobs:
           shaderc \
           molten-vk \
           ninja \
-          hidapi
-
-    - name: Cache FFTS
-      uses: actions/cache@v4
-      with:
-        path: ~/ffts-prefix
-        key: ${{ runner.os }}-ffts-prefix
-
-
-    - name: Clone and Build FFTS Library
-      run: |
-        [[ -d ~/ffts-prefix ]] && exit 0
-        cd
-        git clone https://github.com/anthonix/ffts.git
-        cd ffts
-        mkdir build
-        cd build
-        cmake \
-          -DENABLE_SHARED=ON \
-          -DCMAKE_INSTALL_PREFIX=$HOME/ffts-prefix \
-          -DCMAKE_INSTALL_RPATH=$HOME/ffts-prefix/lib \
-          -DCMAKE_MACOSX_RPATH=ON \
-          -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
-          -GNinja \
-          ..
-        ninja
-        sudo ninja install
+          hidapi \
+          fftw
 
     - name: Configure
       run: |
@@ -83,7 +58,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=Release \
           -DBUILD_DOCS=OFF \
           -DBUILD_TESTING=ON \
-          -DCMAKE_PREFIX_PATH="$(brew --prefix)/opt/libomp;$HOME/ffts-prefix" \
+          -DCMAKE_PREFIX_PATH="$(brew --prefix)/opt/libomp" \
           ..
 
     - name: Build

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -58,7 +58,8 @@ jobs:
           wget \
           xzip \
           libhidapi-dev \
-          ccache
+          ccache \
+          libfftw3-dev
 
     - name: Install Docs Dependencies
       if: ${{ matrix.docs }}
@@ -106,31 +107,6 @@ jobs:
         cd VulkanSDK
         curl -LO https://sdk.lunarg.com/sdk/download/${{ env.SDK_VERSION_STANDALONE }}/linux/vulkansdk-linux-x86_64-${{ env.SDK_VERSION_STANDALONE }}.tar.xz
         tar xf vulkansdk-linux-x86_64-${{ env.SDK_VERSION_STANDALONE }}.tar.xz
-
-    - name: Cache FFTS
-      uses: actions/cache@v4
-      with:
-        path: ~/ffts
-        key: ${{ runner.os }}-${{ matrix.os }}-ffts
-
-    - name: Clone and Build FFTS Library
-      run: |
-        [[  ${{ matrix.docs }} = 'false' ]] && export CMAKE_C_COMPILER_LAUNCHER=ccache && export CMAKE_CXX_COMPILER_LAUNCHER=ccache
-        if [[ ! -d ~/ffts ]]; then
-          cd
-          git clone https://github.com/anthonix/ffts.git
-          cd ffts
-          mkdir build
-          cd build
-          cmake \
-            -DENABLE_SHARED=ON \
-            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
-            -GNinja \
-            ..
-          ninja
-        fi
-        cd ~/ffts/build
-        sudo ninja install
 
     - name: Configure
       run: |

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -48,7 +48,7 @@ jobs:
           shaderc:p
           glslang:p
           spirv-tools:p
-          ffts:p
+          fftw:p
           hidapi:p
           libpng:p
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,12 +130,6 @@ if(WIN32)
 	add_compile_options(-D_USE_MATH_DEFINES -D_POSIX_THREAD_SAFE_FUNCTIONS)
 endif()
 
-# Detect Apple Silicon as FFTS is not available for it
-if(APPLE AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
-	add_compile_options(-D_APPLE_SILICON)
-	set(APPLE_SILICON TRUE)
-endif()
-
 # Package detection
 find_package(PkgConfig MODULE REQUIRED)
 
@@ -282,13 +276,6 @@ add_subdirectory(devdoc)
 
 # Unit tests
 if(Git_FOUND AND BUILD_TESTING)
-	# find ffts, except on Apple Silicon where it's not supported
-	if(NOT APPLE_SILICON)
-		# ffts ships a broken pkgconfig file on some platforms so we are not going to use it
-		find_path(LIBFFTS_INCLUDE_DIRS ffts.h PATH_SUFFIXES ffts REQUIRED)
-		find_library(LIBFFTS_LIBRARIES NAMES ffts libffts REQUIRED)
-	endif()
-
 	find_package(Catch2 REQUIRED)
 	include(Catch)
 	#Catch2 v3.x.y have a breaking change:

--- a/msys2/PKGBUILD
+++ b/msys2/PKGBUILD
@@ -14,7 +14,7 @@ depends=(
   "${MINGW_PACKAGE_PREFIX}-libsigc++"
   "${MINGW_PACKAGE_PREFIX}-cairomm"
   "${MINGW_PACKAGE_PREFIX}-yaml-cpp"
-  "${MINGW_PACKAGE_PREFIX}-ffts"
+  "${MINGW_PACKAGE_PREFIX}-fftw"
   "${MINGW_PACKAGE_PREFIX}-vulkan-loader"
   "${MINGW_PACKAGE_PREFIX}-glfw"
 )

--- a/src/ngscopeclient/wix/license-paths
+++ b/src/ngscopeclient/wix/license-paths
@@ -1,5 +1,4 @@
 ../LICENSE
-../../ffts/COPYRIGHT
 /mingw64/share/licenses/atk/COPYING
 /mingw64/share/licenses/atkmm/COPYING
 /mingw64/share/licenses/binutils/COPYING.LIB

--- a/tests/Filters/CMakeLists.txt
+++ b/tests/Filters/CMakeLists.txt
@@ -3,25 +3,32 @@ add_executable(Filters
 
 	Filter_Add.cpp
 	Filter_ACRMS.cpp
-	Filter_DeEmbed.cpp
 	Filter_EyePattern.cpp
 	Filter_FIR.cpp
-	Filter_FFT.cpp
 	Filter_Subtract.cpp
 	Filter_Upsample.cpp
 
 	FrequencyMeasurement.cpp
 )
 
-include_directories(Filters
-	${LIBFFTS_INCLUDE_DIRS})
-
 target_link_libraries(Filters
 	scopehal
 	scopeprotocols
 	Catch2::Catch2
-	${LIBFFTS_LIBRARIES}
 	)
+
+pkg_search_module(FFTW fftw3f IMPORTED_TARGET)
+
+if (${FFTW_FOUND})
+	message("Found FFTW3, enabling unit tests which depend on it")
+	target_link_libraries(Filters PkgConfig::FFTW)
+	target_sources(Filters PRIVATE
+			Filter_DeEmbed.cpp
+			Filter_FFT.cpp
+	)
+else ()
+	message("Didn't find FFTW3, disabling tests which depend on it")
+endif ()
 
 #Needed because Windows does not support RPATH and will otherwise not be able to find DLLs when catch_discover_tests runs the executable
 if(WIN32)


### PR DESCRIPTION
This PR closes ngscopeclient/scopehal#757

There are some things that I wasn't sure about, I will mark them inside the code comment region after the PR is submitted, the most notable is that I changed nouts to sines.size() inside the DeEmbed filter test, because otherwise ASAN complained, although the tests ran fine either way.

Windows CI started to fail, but it seems like clang is being more aggressive with some imgui internal function, in other platform it builds fine.