### PR TITLE
Fix imgui not building on distros which don't have wayland headers on the default include path on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,7 @@ endif()
 # We still use gtk on Linux for the file browser dialog in "native" mode)
 if(LINUX)
 	pkg_check_modules(GTK QUIET IMPORTED_TARGET REQUIRED gtk+-3.0)
+	pkg_search_module(WAYLAND_CLIENT wayland-client IMPORTED_TARGET GLOBAL REQUIRED)
 endif()
 
 #WORKAROUND Fedora 38 does not include Threads from the glslang .cmake file, fixed in Fedora 39+

--- a/src/ngscopeclient/CMakeLists.txt
+++ b/src/ngscopeclient/CMakeLists.txt
@@ -196,6 +196,10 @@ target_include_directories(ngscopeclient
 #Linker settings
 if(LINUX)
 	set(PLATFORM_LIBS X11)
+	if(${WAYLAND_CLIENT_FOUND})
+		list(APPEND PLATFORM_LIBS ${WAYLAND_CLIENT_MODULE_NAME})
+		target_include_directories(ngscopeclient SYSTEM PRIVATE ${WAYLAND_CLIENT_INCLUDE_DIRS})
+	endif ()
 else()
 	set(PLATFORM_LIBS "")
 endif()


### PR DESCRIPTION
Commit 4457dd5e35a1452f3fc29529aa200584e1841fcf updated imgui to a version which [pulls in](https://github.com/ngscopeclient/imgui/blob/c21de0084ca6981f1a31ed7e5f0386e6adff5cde/backends/imgui_impl_glfw.cpp#L137) GLFW's wayland implementation in a mandatory way, which requires wayland-client headers.

This builds fine on most distros, however some like openSUSE Tumbleweed  (and presumably Leap too, haven't checked) have `wayland-client.h` in a subdirectory, not in the main include path, which usally is `/usr/include`.

See output of RPM to show the directory structure on Tumbleweed:

```
rpm -ql wayland-devel
/usr/bin/wayland-scanner
/usr/include/wayland
/usr/include/wayland/wayland-client-core.h
/usr/include/wayland/wayland-client-protocol.h
/usr/include/wayland/wayland-client.h
/usr/include/wayland/wayland-cursor.h
/usr/include/wayland/wayland-egl-backend.h
/usr/include/wayland/wayland-egl-core.h
/usr/include/wayland/wayland-egl.h
/usr/include/wayland/wayland-server-core.h
/usr/include/wayland/wayland-server-protocol.h
/usr/include/wayland/wayland-server.h
/usr/include/wayland/wayland-util.h
/usr/include/wayland/wayland-version.h
/usr/lib64/libwayland-client.so
/usr/lib64/libwayland-cursor.so
/usr/lib64/libwayland-egl.so
/usr/lib64/libwayland-server.so
/usr/lib64/pkgconfig/wayland-client.pc
/usr/lib64/pkgconfig/wayland-cursor.pc
/usr/lib64/pkgconfig/wayland-egl-backend.pc
/usr/lib64/pkgconfig/wayland-egl.pc
/usr/lib64/pkgconfig/wayland-scanner.pc
/usr/lib64/pkgconfig/wayland-server.pc
/usr/share/aclocal
/usr/share/aclocal/wayland-scanner.m4
/usr/share/wayland
/usr/share/wayland/wayland-scanner.mk
/usr/share/wayland/wayland.dtd
/usr/share/wayland/wayland.xml
```

This change builds fine on all Linux distros in CI, wayland-client libraries are pulled in implicitly already, but if needed I can update the docs to include installation of this library

