### PR TITLE
Fix waveform dragging crash 

### DIFF
--- a/src/ngscopeclient/WaveformArea.h
+++ b/src/ngscopeclient/WaveformArea.h
@@ -483,11 +483,17 @@ public:
 		if(s)
 			return s->GetStream();
 		else
-			return nullptr;	//should never happen
+			// Can happen if waveform has been dragged away
+			return nullptr;	
 	}
 
 	std::shared_ptr<DisplayedChannel> GetDisplayedChannel(size_t i)
-	{ return std::dynamic_pointer_cast<DisplayedChannel>(m_inputs[i]); }
+	{
+		// If the waveform has been dragged away, m_inputs can be empty.
+		if(i < m_inputs.size())
+			return std::dynamic_pointer_cast<DisplayedChannel>(m_inputs[i]); 
+		else return nullptr;
+	}
 
 	bool IsStreamBeingDisplayed(StreamDescriptor target);
 

--- a/src/ngscopeclient/WaveformGroup.cpp
+++ b/src/ngscopeclient/WaveformGroup.cpp
@@ -251,7 +251,9 @@ bool WaveformGroup::Render()
 	float plotWidth = clientArea.x - yAxisWidthSpaced;
 
 	//Update X axis unit
-	if(!areas.empty())
+	// Check if the area has a stream, it could have been moved to another
+	// waveform area and we have not closed this waveform group as a result.
+	if(!areas.empty() && areas[0]->GetStreamCount() > 0)
 	{
 		m_displayingEye = false;
 		m_xAxisUnit = areas[0]->GetStream(0).GetXAxisUnits();


### PR DESCRIPTION
Fixes #983 

If the waveform is dragged to another group, the stream is removed and m_inputs may be empty. 
In the render function of the original area, we try to access m_inputs before the deletion logic happens.